### PR TITLE
LL-7511 - Creating chart component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,8 +21,12 @@
   },
   "dependencies": {
     "@tippyjs/react": "^4.2.5",
+    "chart.js": "^3.5.1",
+    "chartjs-adapter-moment": "^1.0.0",
     "color": "^3.1.3",
+    "moment": "^2.29.1",
     "react": "^17.0.2",
+    "react-chartjs-2": "^3.0.5",
     "react-dom": "^17.0.2",
     "react-select": "^3.2.0",
     "react-transition-group": "^4.4.2",

--- a/packages/react/src/components/Chart/Chart.stories.tsx
+++ b/packages/react/src/components/Chart/Chart.stories.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+
+import Chart from "./index";
+import type { Props as ChartPreviewProps } from "./index";
+import Flex from "@ui/components/layout/Flex";
+import Button from "@ui/components/cta/Button";
+import styled, { useTheme } from "styled-components";
+import type { Item } from "./types";
+
+function getRandomChartDate() {
+  const fromTime = new Date("2020-09-01T01:57:45.271Z");
+  const toTime = new Date("2021-02-12T01:57:45.271Z");
+  return new Date(fromTime.getTime() + Math.random() * (toTime.getTime() - fromTime.getTime()));
+}
+
+function getRandomChartValue() {
+  const min = 1_000;
+  const max = 2_500_000;
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+const generateData = () => {
+  return new Array(50)
+    .fill({})
+    .map(() => ({ value: getRandomChartValue(), date: getRandomChartDate() } as Item))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+};
+
+export default {
+  title: "Charts/Chart",
+  component: Chart,
+  argTypes: {
+    data: {
+      control: false,
+      description:
+        "Date is the only accepted type on the x-axis. On the y-axis, number and string are accepted.",
+    },
+    color: {
+      type: "string",
+      control: "color",
+      defaultValue: "#0EBDCD",
+      description:
+        "This property defines the color of the stroke and the color used to created the gradient. This property any color format.",
+    },
+    valueKey: {
+      control: false,
+      description:
+        "This optional property is useful to override the key in charge of storing the value used on the x-axis.",
+    },
+    variant: {
+      type: "enum",
+      defaultValue: "default",
+      description:
+        "The small variant is used to display a gridless, tickerless chart. The default one is a full chart that allows more controls and optimisations.",
+      options: ["default", "small"],
+      control: false,
+    },
+    timeOptions: {
+      type: "object",
+      description:
+        "This optional property is only used by the default variant to know how to format ticker on the x-axis. See https://www.chartjs.org/docs/latest/axes/cartesian/time.html#time-units.",
+      control: { type: "object" },
+      defaultValue: { unit: "month", displayFormats: { month: "MMM." } },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "This component chart componnet has two variants, the default and the small one. The small one is like a preview, it has no controls and allow less optimisations. The default one is a component that displays grid, axis, tickers and allow lot of customisation.",
+      },
+    },
+  },
+};
+
+export const Default = ({ data: _, ...args }: ChartPreviewProps): JSX.Element => {
+  const [data, setData] = React.useState(generateData());
+
+  const handleClick = () => setData(generateData());
+
+  return (
+    <Flex alignItems="flex-start" flexDirection="column" rowGap="1.5rem">
+      <Flex
+        style={
+          args.variant === "default"
+            ? { position: "relative", width: "100%", aspectRatio: "2 / 1" }
+            : {}
+        }
+      >
+        <Chart {...args} data={data} />
+      </Flex>
+      <Button type="secondary" onClick={handleClick}>
+        Generate new data
+      </Button>
+    </Flex>
+  );
+};
+
+const CardChart = styled.div`
+  position: relative;
+  width: 221px;
+  height: 86px;
+`;
+
+export const Small = (args: ChartPreviewProps): JSX.Element => {
+  const theme = useTheme();
+  const [data, setData] = React.useState(generateData());
+
+  const handleClick = () => setData(generateData());
+
+  return (
+    <Flex alignItems="flex-start" flexDirection="column" rowGap="1rem">
+      <Flex flexWrap="wrap" rowGap="1.5rem" columnGap="2rem">
+        <CardChart>
+          <Chart
+            id="static"
+            variant="small"
+            color={theme.colors.palette.primary.c100}
+            data={data}
+          />
+        </CardChart>
+        <CardChart>
+          <Chart id="dynamic" variant="small" color={args.color} data={data} />
+        </CardChart>
+      </Flex>
+      <Button type="secondary" onClick={handleClick}>
+        Generate new data
+      </Button>
+    </Flex>
+  );
+};

--- a/packages/react/src/components/Chart/index.tsx
+++ b/packages/react/src/components/Chart/index.tsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useMemo } from "react";
+import { Line, defaults } from "react-chartjs-2";
+import type { Props as ChartProps } from "react-chartjs-2/dist/types";
+import type { ScriptableContext } from "chart.js";
+import Color from "color";
+import { useTheme } from "styled-components";
+import "chartjs-adapter-moment";
+
+import type { Item, timeOptions } from "./types";
+import { fontConfig, valueFormatter } from "./utils";
+
+export type Props = Omit<ChartProps, "type" | "data" | "options"> & {
+  data: Array<Item>;
+  color: string;
+  variant?: "default" | "small";
+  valueKey?: string;
+  /*
+   ** This prop is used to format the x-axis using time options from chart.js.
+   ** See https://www.chartjs.org/docs/latest/axes/cartesian/time.html#time-units
+   */
+  timeOptions?: timeOptions;
+};
+
+/*
+ ** @DEV: I'm sorry, I spent too much time to try to type scales. Types from chart.js
+ ** are horrible. I hope someone in the future will have more luck than me.
+ */
+type GetConfigOutput = { gradient: { alpha: number }; scales: unknown };
+
+/*
+ ** Returns the correct config based on the variant
+ */
+const getConfig = (
+  variant: NonNullable<Props["variant"]>,
+  options: NonNullable<Pick<Props, "timeOptions">> & { gridColor: string },
+): GetConfigOutput => {
+  const config: { small: GetConfigOutput; default: GetConfigOutput } = {
+    small: {
+      gradient: { alpha: 0.3 },
+      scales: { y: { display: false }, x: { display: false, type: "time" } },
+    },
+    default: {
+      gradient: { alpha: 0.1 },
+      scales: {
+        y: {
+          display: true,
+          grid: {
+            color: options.gridColor,
+            borderDash: [4, 4],
+            tickWidth: 0,
+            tickLength: 18,
+
+            // This is an hack to don't render a duplicate axis
+            borderWidth: 0,
+          },
+          ticks: { callback: valueFormatter, labelOffset: -3 },
+        },
+        x: {
+          display: true,
+          grid: {
+            color: options.gridColor,
+            borderDash: [4, 4],
+            tickWidth: 0,
+            tickLength: 15,
+
+            // Don't render a duplicate axis
+            borderWidth: 0,
+          },
+          // always display first/last ticks
+          bounds: "ticks",
+          type: "time",
+          // control how the tickers on the x-axis are formatted
+          time: options.timeOptions,
+        },
+      },
+    },
+  };
+
+  return config[variant];
+};
+
+const defaultValue: {
+  variant: NonNullable<Props["variant"]>;
+  valueKey: NonNullable<Props["valueKey"]>;
+  timeOptions: NonNullable<Props["timeOptions"]>;
+} = {
+  variant: "default",
+  valueKey: "value",
+  timeOptions: { unit: "month", displayFormats: { month: "MMM." } },
+};
+
+/**
+ * @remarks This component must have a parent that has only it as a child and it must be in relative position!
+ * @privateRemarks Don't name this component "Chart", that will conflict with the Chart.js library cuz of the adapter
+ */
+export default ({
+  data,
+  color,
+  variant = defaultValue.variant,
+  valueKey = defaultValue.valueKey,
+  timeOptions = defaultValue.timeOptions,
+  ...chartProps
+}: Props): JSX.Element => {
+  const theme = useTheme();
+  const config = useMemo(
+    () => getConfig(variant, { gridColor: theme.colors.palette.neutral.c40, timeOptions }),
+    [variant, theme.colors.palette.neutral.c40, timeOptions],
+  );
+
+  // inject default font configuration at mount
+  useEffect(() => {
+    defaults.font = fontConfig;
+  }, []);
+
+  const chartData = useMemo(
+    () => ({
+      datasets: [
+        {
+          borderColor: color,
+          borderWidth: 2,
+          fill: "start",
+          backgroundColor: (context: ScriptableContext<"bar">) => {
+            const chart = context.chart;
+            const { ctx, chartArea } = chart;
+
+            // This case happens on initial chart load
+            if (!chartArea) return null;
+
+            // Create gradient based on the props color
+            const gradient = ctx.createLinearGradient(0, 0, 0, chartArea.height / 1.2);
+            gradient.addColorStop(0, Color(color).alpha(config.gradient.alpha).string());
+            gradient.addColorStop(1, Color(color).alpha(0.0).string());
+            return gradient;
+          },
+
+          // prevent points rendering
+          pointRadius: 0,
+          pointHitRadius: 0,
+
+          data: data.map(({ date: x, [`${valueKey}`]: y }) => ({ x, y })),
+        },
+      ],
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [color, data, valueKey, variant],
+  ) as unknown as ChartProps["data"];
+
+  const options: ChartProps["options"] = useMemo(
+    () => ({
+      // Responsive options use the parent element to create the canvas
+      responsive: true,
+      maintainAspectRatio: false,
+
+      plugins: { tooltips: { enabled: false }, legend: { display: false } },
+      animation: false,
+      elements: {
+        points: { radius: 0 },
+        line: {
+          // Bezier curve tension of the line. Set to 0 to draw straightlines.
+          tension: 0.2,
+        },
+      },
+      scales: config.scales,
+    }),
+    [config.scales],
+  ) as unknown as ChartProps["options"];
+
+  // The redraw is needed to allow the chart to be updated with new value
+  return <Line data={chartData} options={options} {...chartProps} redraw />;
+};

--- a/packages/react/src/components/Chart/types.ts
+++ b/packages/react/src/components/Chart/types.ts
@@ -1,0 +1,20 @@
+export type Item = {
+  date: Date;
+  value?: number | string;
+} & { [key: string]: number | string };
+
+type Unit =
+  | "millisecond"
+  | "second"
+  | "minute"
+  | "hour"
+  | "day"
+  | "week"
+  | "month"
+  | "quarter"
+  | "year";
+
+export type timeOptions = {
+  unit?: Unit;
+  displayFormats?: { [unit in Unit]?: string };
+};

--- a/packages/react/src/components/Chart/utils.ts
+++ b/packages/react/src/components/Chart/utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Returns the value fixed to 1 decimals when needed with his associated unit (e.g. "1.5K" or "1.5M")
+ * @param value - Value displayed on the y-axis as a tick
+ * @example
+ * ```
+ * valueFormatter(1500) // "1.5K"
+ * valueFormatter(1567) // "1.5K"
+ * valueFormatter(1567657) // "1.5M"
+ * valueFormatter(156) // "156"
+ * ```
+ */
+export const valueFormatter = (value: string | number): string => {
+  const breakpoints = [
+    { value: 1e6, unit: "M" },
+    { value: 1e3, unit: "K" },
+    { value: 1, unit: "" },
+  ];
+
+  const item = breakpoints.find((item) => value >= item.value);
+  const formatedValue = typeof value === "number" ? value : parseFloat(value);
+  return item ? `${(formatedValue / item.value).toFixed(1).replace(".0", "")} ${item.unit}` : "0";
+};
+
+// set default font configuration for the chart - I used ll-text_subTitle class from our theme
+export const fontConfig: {
+  family: string;
+  size: number;
+  weight: string;
+  lineHeight: number;
+  style: "normal" | "italic";
+} = {
+  family: "Inter, Arial",
+  size: 11,
+  weight: "600",
+  lineHeight: 1.21,
+  style: "normal",
+};

--- a/packages/react/yarn.lock
+++ b/packages/react/yarn.lock
@@ -3950,6 +3950,16 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
+chart.js@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.5.1.tgz#73e24d23a4134a70ccdb5e79a917f156b6f3644a"
+  integrity sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==
+
+chartjs-adapter-moment@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-moment/-/chartjs-adapter-moment-1.0.0.tgz#9174b1093c68bcfe285aff24f7388ad60d44e8f7"
+  integrity sha512-PqlerEvQcc5hZLQ/NQWgBxgVQ4TRdvkW3c/t+SUEQSj78ia3hgLkf2VZ2yGJtltNbEEFyYGm+cA6XXevodYvWA==
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -7414,6 +7424,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8438,6 +8453,13 @@ raw-loader@^4.0.2:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+react-chartjs-2@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-3.0.5.tgz#afc23993a32e146bdcc9addff16a28d8964b98ad"
+  integrity sha512-fYr4E82agaZi9IFMe5GtOZ6WE/HWdxy/KywLNOzXsqgPkD2oo1IlrQLKMLUki/2UXko3p95TR2L8Q2rEss/opQ==
+  dependencies:
+    lodash "^4.17.19"
 
 react-colorful@^5.1.2:
   version "5.5.0"


### PR DESCRIPTION
[LL-7511]

This commit includes a new chart component with two variants
- A small one to display a minimalist chart with no controls
- A default one to display a customisable chart with much more infos and controls

In order to create this component, this commit includes 4 new libraries:
- chart.js which is the library we use to generate charts
- react-chartjs-2 which is the React wrapper for chart.js
- moment used to manipulate dates (especially for the x-axis)
- chartjs-adapter-moment which is the adapter required by chart.js to use moment

---

Demo: https://ledger-live-ui-react-a59r1jj09-ledgerhq.vercel.app/?path=/story/charts-chart--default

https://user-images.githubusercontent.com/33158502/136585911-602b2e38-a576-4f2d-b937-c6b0569c20c4.mov


https://user-images.githubusercontent.com/33158502/136585942-8da67e78-7fe2-40db-bbb4-e9b3b1369a02.mov



[LL-7511]: https://ledgerhq.atlassian.net/browse/LL-7511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ