### PR TITLE
Fix styling for disabled and active sidebar items

### DIFF
--- a/packages/react/src/components/navigation/sideBar/Item/Item.stories.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.stories.tsx
@@ -21,8 +21,8 @@ export default {
     },
     onClick: { control: false },
     children: { control: false },
-    isActive: { control: false },
-    isDisabled: { control: false },
+    isActive: { type: "boolean" },
+    isDisabled: { type: "boolean" },
   },
 };
 

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -4,7 +4,7 @@ import SideBarContext from "../index";
 import Text from "../../../asorted/Text";
 import TransitionInOut from "../../../transitions/TransitionInOut";
 
-const ItemWrapper = styled.li`
+const ItemWrapper = styled.li<{ isActive?: boolean; isDisabled?: boolean }>`
   /** DEFAULT VARIANT **/
   --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
   --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};
@@ -38,20 +38,22 @@ const ItemWrapper = styled.li`
   }
 
   /** ACTIVE VARIANT **/
-  &[data-active] {
-    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c100};
-    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.primary.c90};
-    --ll-sidebar-item-background-color: ${(props) => props.theme.colors.palette.primary.c20};
-  }
+  ${(props) =>
+    props.isActive
+      ? `--ll-sidebar-item-label-color: ${props.theme.colors.palette.neutral.c100};
+        --ll-sidebar-item-icon-color: ${props.theme.colors.palette.primary.c90};
+        --ll-sidebar-item-background-color: ${props.theme.colors.palette.primary.c20};`
+      : ""}
 
   /** DISABLE VARIANT **/
-  &[data-disable] {
-    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
-    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};
-    --ll-sidebar-item-background-color: unset;
-    opacity: 0.3;
-    cursor: unset;
-  }
+  ${(props) =>
+    props.isDisabled
+      ? `--ll-sidebar-item-label-color: ${props.theme.colors.palette.neutral.c80};
+        --ll-sidebar-item-icon-color: ${props.theme.colors.palette.neutral.c80};
+        --ll-sidebar-item-background-color: unset;
+        opacity: 0.3;
+        cursor: unset;`
+      : ""}
 `;
 
 export const ItemLabel = styled(Text)`
@@ -81,8 +83,8 @@ const Item = ({ label, children, onClick, isActive, isDisabled }: ItemType): JSX
     <ItemWrapper
       role="button"
       onClick={handleClick}
-      data-active={isActive}
-      data-disable={isDisabled}
+      isActive={isActive}
+      isDisabled={isDisabled}
       tabIndex={0}
     >
       {children}

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -4,7 +4,7 @@ import SideBarContext from "../index";
 import Text from "../../../asorted/Text";
 import TransitionInOut from "../../../transitions/TransitionInOut";
 
-const ItemWrapper = styled.li<{ isActive?: boolean; isDisabled?: boolean }>`
+const ItemWrapper = styled.li`
   /** DEFAULT VARIANT **/
   --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
   --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -38,22 +38,20 @@ const ItemWrapper = styled.li<{ isActive?: boolean; isDisabled?: boolean }>`
   }
 
   /** ACTIVE VARIANT **/
-  ${(props) =>
-    props.isActive
-      ? `--ll-sidebar-item-label-color: ${props.theme.colors.palette.neutral.c100};
-        --ll-sidebar-item-icon-color: ${props.theme.colors.palette.primary.c90};
-        --ll-sidebar-item-background-color: ${props.theme.colors.palette.primary.c20};`
-      : ""}
+  &[data-active="true"] {
+    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c100};
+    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.primary.c90};
+    --ll-sidebar-item-background-color: ${(props) => props.theme.colors.palette.primary.c20};
+  }
 
   /** DISABLE VARIANT **/
-  ${(props) =>
-    props.isDisabled
-      ? `--ll-sidebar-item-label-color: ${props.theme.colors.palette.neutral.c80};
-        --ll-sidebar-item-icon-color: ${props.theme.colors.palette.neutral.c80};
-        --ll-sidebar-item-background-color: unset;
-        opacity: 0.3;
-        cursor: unset;`
-      : ""}
+  &[data-disable="true"] {
+    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
+    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};
+    --ll-sidebar-item-background-color: unset;
+    opacity: 0.3;
+    cursor: unset;
+  }
 `;
 
 export const ItemLabel = styled(Text)`
@@ -83,8 +81,8 @@ const Item = ({ label, children, onClick, isActive, isDisabled }: ItemType): JSX
     <ItemWrapper
       role="button"
       onClick={handleClick}
-      isActive={isActive}
-      isDisabled={isDisabled}
+      data-active={isActive}
+      data-disable={isDisabled}
       tabIndex={0}
     >
       {children}


### PR DESCRIPTION
The styling wasn't correctly taking into account the isDisabled and isActive properties. The specific styles were being activated whenever the props were defined as anything instead of only when they were truthy. 