### PR TITLE
Native storybook type checking

### DIFF
--- a/packages/native/.storybook/webpack.config.js
+++ b/packages/native/.storybook/webpack.config.js
@@ -2,22 +2,14 @@ const { resolve } = require("path");
 const { withUnimodules } = require("@expo/webpack-config/addons");
 
 module.exports = ({ config }) => {
-  // Alternately, for an alias:
-  config.resolve.alias = {
-    ...config.resolve.alias,
-    "@ui": resolve(__dirname, "..", "src"),
-    "@assets": resolve(__dirname, "..", "src", "assets"),
-    "@styles": resolve(__dirname, "..", "src", "styles"),
-    "@components": resolve(__dirname, "..", "src", "components"),
-    "victory-native": "victory"
-  };
   config.resolve.extensions = [".ts", ".tsx", ".js", ".json"];
 
   const babelRule = config.module.rules.find(
     (rule) => rule.exclude.toString() === "/node_modules/"
   );
   if (babelRule)
-    babelRule.exclude = /node_modules\/(?!(@ledgerhq\/ui-shared|victory-native)\/).*/;
+    babelRule.exclude =
+      /node_modules\/(?!(@ledgerhq\/ui-shared|victory-native)\/).*/;
 
   return withUnimodules(config, {
     projectRoot: resolve(__dirname, "../"),

--- a/packages/native/babel.config.js
+++ b/packages/native/babel.config.js
@@ -8,12 +8,6 @@ module.exports = function (api) {
         {
           root: ["./src"],
           extensions: [".ios.js", ".android.js", ".js", ".ts", ".tsx", ".json"],
-          alias: {
-            "~": "./src",
-            "@ui": "./src",
-            "@components": "./src/components",
-            "@assets": "./src/assets",
-          },
         },
       ],
       "@babel/plugin-proposal-export-namespace-from",

--- a/packages/native/metro.config.js
+++ b/packages/native/metro.config.js
@@ -1,11 +1,15 @@
 const path = require("path");
-
 const monoRepoRoot = path.resolve(__dirname, "..", "..");
+const blockList = new RegExp(
+  `^(${__dirname}/lib/.*|${monoRepoRoot}/packages/react/.*)`
+);
 
 module.exports = {
   watchFolders: [monoRepoRoot],
   resolver: {
     resolverMainFields: ["typescriptMain", "browser", "main"],
+    blacklistRE: blockList,
+    blockList: blockList,
   },
   transformer: {
     getTransformOptions: async () => ({

--- a/packages/native/src/components/Form/Input/BaseInput/index.tsx
+++ b/packages/native/src/components/Form/Input/BaseInput/index.tsx
@@ -4,7 +4,7 @@ import styled, { css } from "styled-components/native";
 import Text from "../../../Text";
 import FlexBox from "../../../Layout/Flex";
 
-type CommonProps = TextInputProps & {
+export type CommonProps = TextInputProps & {
   disabled?: boolean;
   error?: string;
 };

--- a/packages/native/src/components/Form/Input/NumberInput/index.tsx
+++ b/packages/native/src/components/Form/Input/NumberInput/index.tsx
@@ -32,7 +32,8 @@ export default function NumberInput({
   ...inputProps
 }: InputProps & {
   onPercentClick: (percent: number) => void;
-  max: number;
+  min?: number;
+  max?: number;
 }): JSX.Element {
   return (
     <Input

--- a/packages/native/src/components/Form/Slider/index.tsx
+++ b/packages/native/src/components/Form/Slider/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
+import type { SliderProps } from "./index.native";
 
-const SliderScreen = () => {
+const SliderScreen = (_props: SliderProps) => {
   return <></>;
 };
 

--- a/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -25,7 +25,7 @@ export type BaseModalProps = {
   description?: string;
   subtitle?: string;
   children: React.ReactNode;
-} & ModalProps;
+} & Partial<ModalProps>;
 
 const Container = styled.View`
   background-color: ${(p) => p.theme.colors.palette.background.main};
@@ -89,7 +89,7 @@ export default function BaseModal({
   subtitle,
   children,
   ...rest
-}: Partial<BaseModalProps>): React.ReactElement {
+}: BaseModalProps): React.ReactElement {
   const { colors } = useTheme();
 
   const backDropProps = preventBackdropClick

--- a/packages/native/src/components/Layout/Table/Row.tsx
+++ b/packages/native/src/components/Layout/Table/Row.tsx
@@ -3,7 +3,7 @@ import FlexBox, { Props as FlexBoxProps } from "../Flex";
 import IconBox from "../../Icon/IconBox";
 
 interface Props extends FlexBoxProps {
-  Icon: (props: { size?: number }) => React.ReactElement;
+  Icon?: (props: { size?: number }) => React.ReactElement;
   iconBorder?: boolean;
   topLeft?: React.ReactNode;
   bottomLeft?: React.ReactNode;

--- a/packages/native/src/components/Loader/index.tsx
+++ b/packages/native/src/components/Loader/index.tsx
@@ -11,7 +11,7 @@ type Props = {
   onPress?: () => void;
 
   // Display an icon in the middle
-  Icon?: typeof React.Component;
+  Icon?: React.ComponentType<{ color: string; size: number }>;
 };
 
 const radius = 25;

--- a/packages/native/src/components/cta/Button/index.tsx
+++ b/packages/native/src/components/cta/Button/index.tsx
@@ -15,7 +15,7 @@ import Text from "../../Text";
 
 export type ButtonProps = TouchableOpacityProps &
   SpaceProps & {
-    Icon?: React.ComponentType<{ size: number; color: string }>;
+    Icon?: React.ComponentType<{ size: number; color: string }> | null;
     type?: "main" | "shade" | "error" | "color" | "default";
     size?: "small" | "medium" | "large";
     iconPosition?: "right" | "left";

--- a/packages/native/src/components/cta/Button/index.tsx
+++ b/packages/native/src/components/cta/Button/index.tsx
@@ -133,7 +133,7 @@ const Button = (props: ButtonProps): React.ReactElement => {
       {...props}
       type={type}
       size={size}
-      iconButton={Icon && !children}
+      iconButton={!!Icon && !children}
       activeOpacity={0.5}
     >
       <ButtonContainer {...props} type={type} size={size} />
@@ -172,7 +172,7 @@ export const PromisableButton = (props: ButtonProps): React.ReactElement => {
       {...props}
       type={type}
       size={size}
-      iconButton={Icon && !children}
+      iconButton={!!Icon && !children}
       disabled={disabled || spinnerOn}
       onPress={onPressHandler}
     >

--- a/packages/native/storybook/index.tsx
+++ b/packages/native/storybook/index.tsx
@@ -19,7 +19,9 @@ const ledgerTheme = {
 };
 
 // enables knobs for all stories
-addDecorator((Story) => (
+// (putting any type because bindings are incorrect)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+addDecorator((Story: any) => (
   <CenterView waitFonts>
     <Story />
   </CenterView>

--- a/packages/native/storybook/stories/Button/Button.stories.tsx
+++ b/packages/native/storybook/stories/Button/Button.stories.tsx
@@ -8,16 +8,22 @@ import Info from "../../../src/icons/Info";
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const iconOptions = {
+  Info,
+  None: undefined,
+};
+const iconSelect = () => iconOptions[select("Icon", ["Info", "None"], "None")];
+
 const Regular = (): JSX.Element => (
   <Button
     type={select(
       "type",
       ["main", "error", "shade", "color", undefined],
-      undefined
+      "main"
     )}
     size={select("size", ["small", "medium", "large", undefined], undefined)}
     iconPosition={select("iconPosition", ["right", "left"], "right")}
-    Icon={select("Icon", [Info, undefined], undefined)}
+    Icon={iconSelect()}
     disabled={boolean("disabled", false)}
     outline={boolean("outline", false)}
     onPress={action("onPress")}
@@ -25,12 +31,15 @@ const Regular = (): JSX.Element => (
     {text("label", "Ledger")}
   </Button>
 );
-
 const Promisable = (): JSX.Element => (
   <PromisableButton
-    type={select("type", ["primary", "secondary", undefined], undefined)}
+    type={select(
+      "type",
+      ["main", "shade", "error", "color", "default", undefined],
+      undefined
+    )}
     iconPosition={select("iconPosition", ["right", "left"], "right")}
-    Icon={select("Icon", [Info, undefined], undefined)}
+    Icon={iconSelect()}
     disabled={boolean("disabled", false)}
     onPress={async () => await delay(3000)}
   >

--- a/packages/native/storybook/stories/Button/Button.stories.tsx
+++ b/packages/native/storybook/stories/Button/Button.stories.tsx
@@ -3,10 +3,10 @@ import { storiesOf } from "../storiesOf";
 import { select, boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import React from "react";
-import Button, { PromisableButton } from "@components/cta/Button";
-import Info from "@ui/icons/Info";
+import Button, { PromisableButton } from "../../../src/components/cta/Button";
+import Info from "../../../src/icons/Info";
 
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const Regular = (): JSX.Element => (
   <Button

--- a/packages/native/storybook/stories/CenterView/index.tsx
+++ b/packages/native/storybook/stories/CenterView/index.tsx
@@ -56,11 +56,9 @@ export function FontProvider({
 export default function CenterView({
   waitFonts,
   children,
-  theme,
 }: {
   waitFonts?: boolean;
   children: React.ReactNode;
-  theme?: "dark" | "light";
 }): JSX.Element {
   const [isLight, setIsLight] = useState(true);
   return (

--- a/packages/native/storybook/stories/Chart/Chart.stories.tsx
+++ b/packages/native/storybook/stories/Chart/Chart.stories.tsx
@@ -35,7 +35,7 @@ const ChartDefault = (): JSX.Element => {
   const theme = useTheme();
 
   return (
-    <Flex alignItems="flex-start" flexDirection="column" rowGap="1rem">
+    <Flex alignItems="flex-start" flexDirection="column">
       <Chart
         color={color("color", theme.colors.palette.primary.c100)}
         tickFormat={text("tickFormat", "MMM")}

--- a/packages/native/storybook/stories/Form/Checkbox.stories.tsx
+++ b/packages/native/storybook/stories/Form/Checkbox.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { storiesOf } from "../storiesOf";
 import { boolean, text } from "@storybook/addon-knobs";
 
-import Checkbox from "@components/Form/Checkbox";
+import Checkbox from "../../../src/components/Form/Checkbox";
 
 const CheckboxStory = () => {
   const [checked, setChecked] = useState(false);

--- a/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
@@ -1,11 +1,11 @@
 import { storiesOf } from "../../storiesOf";
 import { boolean, text } from "@storybook/addon-knobs";
 import React, { useState } from "react";
-import Button from "@components/cta/Button";
+import Button from "../../../../src/components/cta/Button";
 import Input, {
   InputRenderLeftContainer,
   InputRenderRightContainer,
-} from "@components/Form/Input/BaseInput";
+} from "../../../../src/components/Form/Input/BaseInput";
 
 const BaseInputStory = () => {
   const [value, setValue] = useState("");

--- a/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
@@ -5,12 +5,13 @@ import Button from "../../../../src/components/cta/Button";
 import Input, {
   InputRenderLeftContainer,
   InputRenderRightContainer,
+  CommonProps,
 } from "../../../../src/components/Form/Input/BaseInput";
 
 const BaseInputStory = () => {
   const [value, setValue] = useState("");
 
-  const onChangeText = (value) => setValue(value);
+  const onChangeText = (value: string) => setValue(value);
 
   return (
     <Input
@@ -26,16 +27,16 @@ const BaseInputStory = () => {
 const BaseInputRenderSideExempleStory = () => {
   const [value, setValue] = useState("test@ledger.fr");
   const [disabled, setDisabled] = useState(false);
-  const [error, setError] = React.useState(false);
+  const [error, setError] = React.useState<string | undefined>();
 
-  const onChangeText = (value) => setValue(value);
+  const onChangeText = (value: string) => setValue(value);
 
   const renderLeft = (
     <InputRenderLeftContainer>
       <Button onPress={() => setDisabled(!disabled)}>disable</Button>
     </InputRenderLeftContainer>
   );
-  const renderRight = (props) => {
+  const renderRight = (props: CommonProps) => {
     return (
       <InputRenderRightContainer>
         <Button

--- a/packages/native/storybook/stories/Form/Input/LegendInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/LegendInput.stories.tsx
@@ -6,7 +6,7 @@ import LegendInput from "../../../../src/components/Form/Input/LegendInput";
 const LegendInputStory = (): JSX.Element => {
   const [value, setValue] = React.useState("");
 
-  const onChange = (value) => setValue(value);
+  const onChange = (value: string) => setValue(value);
 
   return (
     <LegendInput

--- a/packages/native/storybook/stories/Form/Input/NumberInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/NumberInput.stories.tsx
@@ -5,19 +5,22 @@ import { number } from "@storybook/addon-knobs";
 
 const NumberInputStory = () => {
   const [value, setValue] = React.useState(24.42);
-  const max = number("max", undefined);
-  const min = number("min", undefined)
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const max = number("max", undefined as any);
+  const min = number("min", undefined as any);
+  /* esline-enable @typescript-eslint/no-explicit-any */
 
   // FixMe: Naive implementation, only for story demo
-  const onChange = (value) => {
-    if (value) {
-      if (max && value > max) value = max;
-      if (min && value < min) value = min;
+  const onChange = (value: string) => {
+    let nb = parseInt(value);
+    if (nb) {
+      if (max && nb > max) nb = max;
+      if (min && nb < min) nb = min;
     }
-    setValue(value);
+    setValue(nb);
   };
 
-  const onPercentClick = (percent) => {
+  const onPercentClick = (percent: number) => {
     setValue(max * percent);
   };
 
@@ -27,8 +30,8 @@ const NumberInputStory = () => {
       onChangeText={onChange}
       onPercentClick={onPercentClick}
       placeholder={"Placeholder"}
-      max={max}
       min={min}
+      max={max}
     />
   );
 };

--- a/packages/native/storybook/stories/Form/Input/QrCodeInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/QrCodeInput.stories.tsx
@@ -1,16 +1,14 @@
 import { storiesOf } from "../../storiesOf";
 import React from "react";
-import { InputProps } from "../../../../src/components/Form/Input/BaseInput";
 import QrCodeInput from "../../../../src/components/Form/Input/QrCodeInput";
 
-const QrCodeInputStory = (args: InputProps): JSX.Element => {
+const QrCodeInputStory = (): JSX.Element => {
   const [value, setValue] = React.useState("");
 
-  const onChange = (value) => setValue(value);
+  const onChange = (value: string) => setValue(value);
 
   return (
     <QrCodeInput
-      {...args}
       value={value}
       onChangeText={onChange}
       placeholder={"Placeholder"}

--- a/packages/native/storybook/stories/Form/Input/SearchInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/SearchInput.stories.tsx
@@ -5,7 +5,7 @@ import SearchInput from "../../../../src/components/Form/Input/SearchInput";
 const SearchInputStory = (): JSX.Element => {
   const [value, setValue] = React.useState("");
 
-  const onChange = (value) => setValue(value);
+  const onChange = (value: string) => setValue(value);
 
   return (
     <SearchInput

--- a/packages/native/storybook/stories/Form/Slider/Slider.stories.tsx
+++ b/packages/native/storybook/stories/Form/Slider/Slider.stories.tsx
@@ -7,7 +7,7 @@ import FlexBox from "../../../../src/components/Layout/Flex";
 const SliderStory = () => {
   const [value, setValue] = useState(35);
 
-  const onChange = (value) => setValue(value);
+  const onChange = (value: number) => setValue(value);
 
   return (
     <FlexBox p={20} width={1}>

--- a/packages/native/storybook/stories/Form/Slider/Slider.stories.tsx
+++ b/packages/native/storybook/stories/Form/Slider/Slider.stories.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { storiesOf } from "../../storiesOf";
 import { boolean, number } from "@storybook/addon-knobs";
-import Slider from "@components/Form/Slider";
-import FlexBox from "@components/Layout/Flex";
+import Slider from "../../../../src/components/Form/Slider";
+import FlexBox from "../../../../src/components/Layout/Flex";
 
 const SliderStory = () => {
   const [value, setValue] = useState(35);

--- a/packages/native/storybook/stories/Form/Switch.stories.tsx
+++ b/packages/native/storybook/stories/Form/Switch.stories.tsx
@@ -2,7 +2,7 @@ import { storiesOf } from "../storiesOf";
 import { boolean, text } from "@storybook/addon-knobs";
 
 import React, { useState } from "react";
-import Switch from "@components/Form/Switch";
+import Switch from "../../../src/components/Form/Switch";
 
 const SwitchStory = () => {
   const [checked, setChecked] = useState(false);

--- a/packages/native/storybook/stories/Layout/Flex.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Flex.stories.tsx
@@ -19,14 +19,22 @@ const FlexStory = () => {
   );
   const justifyContent = select(
     "Justify Content",
-    ["flex-start", "flex-end", "center", "baseline", "stretch"],
+    [
+      "flex-start",
+      "flex-end",
+      "center",
+      "space-around",
+      "space-between",
+      "space-evenly",
+      undefined,
+    ],
     "flex-start",
     "Layout"
   );
   const background = text("Background", "", "Layout");
-  const flexBasis = text("FlexBasis", "", "Layout");
-  const flexGrow = text("FlexGrow", "", "Layout");
-  const flexShrink = text("FlexShrink", "", "Layout");
+  const flexBasis = text("FlexBasis", "auto", "Layout");
+  const flexGrow = number("FlexGrow", 0, undefined, "Layout");
+  const flexShrink = number("FlexShrink", 0, undefined, "Layout");
 
   const p = number("Padding", 0, {}, "Layout");
   const m = number("Margin", 0, {}, "Layout");
@@ -64,15 +72,23 @@ const FlexStoryTwo = () => {
     "Layout"
   );
   const justifyContent = select(
-    "JustifyContent",
-    ["flex-start", "flex-end", "center", "baseline", "stretch"],
+    "Justify Content",
+    [
+      "flex-start",
+      "flex-end",
+      "center",
+      "space-around",
+      "space-between",
+      "space-evenly",
+      undefined,
+    ],
     "flex-start",
     "Layout"
   );
   const background = text("Background", "", "Layout");
-  const flexBasis = text("FlexBasis", "", "Layout");
-  const flexGrow = text("FlexGrow", "", "Layout");
-  const flexShrink = text("FlexShrink", "", "Layout");
+  const flexBasis = text("FlexBasis", "auto", "Layout");
+  const flexGrow = number("FlexGrow", 0, undefined, "Layout");
+  const flexShrink = number("FlexShrink", 0, undefined, "Layout");
 
   const p = number("Padding", 0, {}, "Layout");
   const m = number("Margin", 0, {}, "Layout");

--- a/packages/native/storybook/stories/Layout/Flex.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Flex.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { storiesOf } from "../storiesOf";
 import { select, text, number } from "@storybook/addon-knobs";
-import Flex from "@components/Layout/Flex";
-import Text from "@components/Text";
+import Flex from "../../../src/components/Layout/Flex";
+import Text from "../../../src/components/Text";
 
 const FlexStory = () => {
   const alignItems = select(

--- a/packages/native/storybook/stories/Layout/Modal/BottomDrawer.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Modal/BottomDrawer.stories.tsx
@@ -2,9 +2,9 @@ import React, { useState, useCallback } from "react";
 import { storiesOf } from "../../storiesOf";
 import { text, button } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import BottomDrawer from "@components/Layout/Modals/BottomDrawer";
-import Text from "@components/Text";
-import Button from "@components/cta/Button";
+import BottomDrawer from "../../../../src/components/Layout/Modals/BottomDrawer";
+import Text from "../../../../src/components/Text";
+import Button from "../../../../src/components/cta/Button";
 import { Icons } from "../../../../src/assets";
 
 const BottomDrawerStory = () => {

--- a/packages/native/storybook/stories/Layout/Modal/BottomDrawer.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Modal/BottomDrawer.stories.tsx
@@ -28,12 +28,10 @@ const BottomDrawerStory = () => {
       subtitle={text("subtitle", "Subtitle")}
       Icon={Icons.TrashMedium}
     >
-      <>
-        <Text>Exemple children</Text>
-        <Button>
-          <Text>button</Text>
-        </Button>
-      </>
+      <Text>Exemple children</Text>
+      <Button>
+        <Text>button</Text>
+      </Button>
     </BottomDrawer>
   );
 };

--- a/packages/native/storybook/stories/Layout/Modal/Modal.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Modal/Modal.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "../../storiesOf";
 import { text, button } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import BaseModal from "../../../../src/components/Layout/Modals/BaseModal";
-import Text from "@components/Text";
+import Text from "../../../../src/components/Text";
 import { Icons } from "../../../../src/assets";
 import IconBox from "../../../../src/components/Icon/IconBox";
 

--- a/packages/native/storybook/stories/Layout/Modal/Popin.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Modal/Popin.stories.tsx
@@ -2,8 +2,8 @@ import React, { useState, useCallback } from "react";
 import { storiesOf } from "../../storiesOf";
 import { text, button } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import Popin from "@components/Layout/Modals/Popin";
-import Text from "@components/Text";
+import Popin from "../../../../src/components/Layout/Modals/Popin";
+import Text from "../../../../src/components/Text";
 import { Icons } from "../../../../src/assets";
 
 const PopinStory = () => {

--- a/packages/native/storybook/stories/Layout/Modal/Tooltip.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Modal/Tooltip.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../../storiesOf";
-import Tooltip from "@components/Layout/Modals/Tooltip";
-import Text from "@components/Text";
+import Tooltip from "../../../../src/components/Layout/Modals/Tooltip";
+import Text from "../../../../src/components/Text";
 import { Icons } from "../../../../src/assets";
 
 const TooltipStory = () => {

--- a/packages/native/storybook/stories/Layout/Notification.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Notification.stories.tsx
@@ -2,9 +2,9 @@ import { storiesOf } from "../storiesOf";
 import { number, select, text } from "@storybook/addon-knobs";
 import React from "react";
 import { Icons } from "../../../src/assets";
-import Notification from "@components/drawer/Notification";
+import Notification from "../../../src/components/drawer/Notification";
 import { action } from "@storybook/addon-actions";
-import FlexBox from "@components/Layout/Flex";
+import FlexBox from "../../../src/components/Layout/Flex";
 import Info from "../../../src/icons/Info";
 
 const NotificationSample = () => (

--- a/packages/native/storybook/stories/Layout/Notification.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Notification.stories.tsx
@@ -5,12 +5,11 @@ import { Icons } from "../../../src/assets";
 import Notification from "../../../src/components/drawer/Notification";
 import { action } from "@storybook/addon-actions";
 import FlexBox from "../../../src/components/Layout/Flex";
-import Info from "../../../src/icons/Info";
 
 const NotificationSample = () => (
   <FlexBox p={20} width={"100%"}>
     <Notification
-      Icon={Info}
+      Icon={Icons.InfoMedium}
       variant={select("variant", ["primary", "secondary"], "primary")}
       title={text(
         "title",

--- a/packages/native/storybook/stories/Layout/Table.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Table.stories.tsx
@@ -75,7 +75,7 @@ const ARow = () => {
   ].map((item) => radios(item, { [item]: 1, null: null }, 1, "props"));
   return (
     <Row
-      Icon={hasIcon && Icon}
+      Icon={hasIcon ? Icon : undefined}
       topLeft={hasTopLeft && <TopLeft />}
       bottomLeft={hasBottomLeft && <BottomLeft />}
       topRight={hasTopRight && <TopRight />}

--- a/packages/native/storybook/stories/Link/Link.stories.tsx
+++ b/packages/native/storybook/stories/Link/Link.stories.tsx
@@ -7,15 +7,15 @@ import Link from "../../../src/components/cta/Link";
 import { InfoMedium } from "@ledgerhq/icons-ui/native";
 
 const Regular = () => (
-    <Link
-      type={select("type", ["main", "shade", "color", undefined], undefined)}
-      size={select("size", ["small", "medium", "large", undefined], undefined)}
-      iconPosition={select("iconPosition", ["right", "left"], "right")}
-      disabled={boolean("disabled", false)}
-      onPress={action("onPress")}
-    >
-      {text("label", "Ledger")}
-    </Link>
+  <Link
+    type={select("type", ["main", "shade", "color", undefined], undefined)}
+    size={select("size", ["small", "medium", "large", undefined], undefined)}
+    iconPosition={select("iconPosition", ["right", "left"], "right")}
+    disabled={boolean("disabled", false)}
+    onPress={action("onPress")}
+  >
+    {text("label", "Ledger")}
+  </Link>
 );
 
 const WithIcon = () => (
@@ -31,5 +31,6 @@ const WithIcon = () => (
   </Link>
 );
 
-
-storiesOf((story) => story("Link", module).add("Regular", Regular).add("Icon link", WithIcon));
+storiesOf((story) =>
+  story("Link", module).add("Regular", Regular).add("Icon link", WithIcon)
+);

--- a/packages/native/storybook/stories/Loader/Loader.stories.tsx
+++ b/packages/native/storybook/stories/Loader/Loader.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { storiesOf } from "../storiesOf";
 import { number } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import Loader from "@components/Loader";
+import Loader from "../../../src/components/Loader";
 import { Icons } from "../../../src/assets";
 
 const LoaderSample = () => (

--- a/packages/native/storybook/stories/Navigation/SlideIndicator/SlideIndicator.stories.tsx
+++ b/packages/native/storybook/stories/Navigation/SlideIndicator/SlideIndicator.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { number } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "../../storiesOf";
-import SlideIndicator from "@components/Navigation/SlideIndicator";
+import SlideIndicator from "../../../../src/components/Navigation/SlideIndicator";
 
 const SideIndicatorSample = () => (
   <SlideIndicator

--- a/packages/native/storybook/stories/Particles/Spacing.stories.tsx
+++ b/packages/native/storybook/stories/Particles/Spacing.stories.tsx
@@ -3,8 +3,8 @@ import { View, ScrollView } from "react-native";
 import { storiesOf } from "../storiesOf";
 import { useTheme } from "styled-components/native";
 
-import Text from "@components/Text";
-import Flex from "@components/Layout/Flex";
+import Text from "../../../src/components/Text";
+import Flex from "../../../src/components/Layout/Flex";
 
 const SpacingStory = () => {
   const theme = useTheme();

--- a/packages/native/storybook/stories/Text/Text.stories.tsx
+++ b/packages/native/storybook/stories/Text/Text.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../storiesOf";
 import { select, boolean } from "@storybook/addon-knobs";
-import Text from "@components/Text";
+import Text from "../../../src/components/Text";
 
 storiesOf((story) =>
   story("Text", module).add("regular", () => (

--- a/packages/native/storybook/stories/message/Alert/Alert.stories.tsx
+++ b/packages/native/storybook/stories/message/Alert/Alert.stories.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../../storiesOf";
 import { select, boolean } from "@storybook/addon-knobs";
-import Alert from "@components/message/Alert";
-import FlexBox from "@components/Layout/Flex";
+import Alert from "../../../../src/components/message/Alert";
+import FlexBox from "../../../../src/components/Layout/Flex";
 
 const AlertSample = () => (
   <FlexBox p={20} width={1}>

--- a/packages/native/tsconfig.json
+++ b/packages/native/tsconfig.json
@@ -6,10 +6,9 @@
     "isolatedModules": true,
     "strict": true,
     "baseUrl": ".",
-    "rootDir": "./src",
-    "outDir": "./lib"
+    "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "storybook/**/*"],
   "exclude": [
     "node_modules",
     "babel.config.js",

--- a/packages/native/tsconfig.prod.json
+++ b/packages/native/tsconfig.prod.json
@@ -6,6 +6,8 @@
     "declaration": true,
     "target": "ES6",
     "noEmit": false,
-    "jsx": "react"
+    "jsx": "react",
+    "rootDir": "./src",
+    "outDir": "./lib"
   }
 }


### PR DESCRIPTION
### Enable the type checker for stories files.

#### Also:

- Removed the path aliases. (`~`, `@component`,  `@ui` …)
- Fixed various type issues.
- Make metro bundler ignore `/lib` folders.