### PR TITLE
core: expose link component globally

### DIFF
--- a/packages/react/src/components/cta/index.ts
+++ b/packages/react/src/components/cta/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from "./Button";
 export { default as Toggle } from "./Toggle";
+export { default as Link } from "./Link";


### PR DESCRIPTION
Allow our consumers to import the Link component directly like this

`import { Link } from "@ledgerhq/react-ui";`