### PR TITLE
LL-7758 Improvements to the Header and SideBar

### DIFF
--- a/packages/react/src/components/navigation/Header/index.tsx
+++ b/packages/react/src/components/navigation/Header/index.tsx
@@ -3,11 +3,11 @@ import FlexBox from "../../layout/Flex";
 
 export type Props = {
   /* Content displayed on the left side of the header. */
-  left: React.ReactNode;
+  left?: React.ReactNode;
   /* Content displayed on the right side of the header. */
-  right: React.ReactNode;
+  right?: React.ReactNode;
   /* Content displayed in the middle part - vertically centered. */
-  children: React.ReactNode;
+  children?: React.ReactNode;
 } & React.ComponentProps<typeof FlexBox>;
 
 export default function ({ left, right, children, ...rest }: Props): JSX.Element {

--- a/packages/react/src/components/navigation/sideBar/Item/Item.stories.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.stories.tsx
@@ -23,6 +23,7 @@ export default {
     children: { control: false },
     isActive: { type: "boolean" },
     isDisabled: { type: "boolean" },
+    displayNotificationBadge: { type: "boolean" },
   },
 };
 

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import SideBarContext from "../index";
 import Text from "../../../asorted/Text";
 import TransitionInOut from "../../../transitions/TransitionInOut";
+import Flex from "../../../layout/Flex";
 
 const ItemWrapper = styled.li`
   /** DEFAULT VARIANT **/
@@ -54,12 +55,17 @@ const ItemWrapper = styled.li`
   }
 `;
 
-const Badge = styled.div`
+const CollapsedBadgeContainer = styled.div`
+  position: absolute;
+  margin-top: -${(p) => p.theme.space[11]}px;
+  margin-left: ${(p) => p.theme.space[8]}px;
+`;
+
+const DefaultBadge = styled.div`
   height: ${(p) => p.theme.space[4]}px;
   width: ${(p) => p.theme.space[4]}px;
   border-radius: ${(p) => p.theme.radii[2]}px;
   background-color: ${(p) => p.theme.colors.palette.primary.c80};
-  margin-left: auto;
 `;
 
 export const ItemLabel = styled(Text)`
@@ -76,6 +82,7 @@ export type ItemType = {
   isActive?: boolean;
   isDisabled?: boolean;
   displayNotificationBadge?: boolean;
+  customNotificationBadge?: JSX.Element;
 };
 
 const Item = ({
@@ -85,6 +92,7 @@ const Item = ({
   isActive,
   isDisabled,
   displayNotificationBadge,
+  customNotificationBadge,
 }: ItemType): JSX.Element => {
   const { isExpanded } = useContext(SideBarContext);
 
@@ -93,26 +101,44 @@ const Item = ({
     onClick();
   };
 
+  const badge = customNotificationBadge ?? <DefaultBadge />;
+
   return (
-    <ItemWrapper
-      role="button"
-      onClick={handleClick}
-      data-active={isActive}
-      data-disable={isDisabled}
-      tabIndex={0}
-    >
-      {children}
-      <TransitionInOut
-        timeout={300}
-        in={isExpanded}
-        unmountOnExit
-        mountOnEnter
-        style={{ transitionDelay: isExpanded ? "300ms" : 0 }}
+    <>
+      <ItemWrapper
+        role="button"
+        onClick={handleClick}
+        data-active={isActive}
+        data-disable={isDisabled}
+        tabIndex={0}
       >
-        <ItemLabel variant="paragraph">{label}</ItemLabel>
-      </TransitionInOut>
-      {displayNotificationBadge && <Badge />}
-    </ItemWrapper>
+        {children}
+        <CollapsedBadgeContainer>
+          <TransitionInOut
+            unmountOnExit
+            mountOnEnter
+            in={!isExpanded}
+            style={{ transitionDelay: !isExpanded ? "300ms" : 0 }}
+          >
+            {displayNotificationBadge && badge}
+          </TransitionInOut>
+        </CollapsedBadgeContainer>
+        <TransitionInOut
+          timeout={300}
+          in={isExpanded}
+          unmountOnExit
+          mountOnEnter
+          style={{ transitionDelay: isExpanded ? "300ms" : 0, flexGrow: 1 }}
+        >
+          <Flex>
+            <ItemLabel variant="paragraph">{label}</ItemLabel>
+            <Flex alignItems="center" justifyContent="flex-end" flexGrow={1}>
+              {displayNotificationBadge && badge}
+            </Flex>
+          </Flex>
+        </TransitionInOut>
+      </ItemWrapper>
+    </>
   );
 };
 

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -54,6 +54,14 @@ const ItemWrapper = styled.li`
   }
 `;
 
+const Badge = styled.div`
+  height: ${(p) => p.theme.space[4]}px;
+  width: ${(p) => p.theme.space[4]}px;
+  border-radius: ${(p) => p.theme.radii[2]}px;
+  background-color: ${(p) => p.theme.colors.palette.primary.c80};
+  margin-left: auto;
+`;
+
 export const ItemLabel = styled(Text)`
   display: inline-block;
   color: var(--ll-sidebar-item-label-color);
@@ -67,9 +75,17 @@ export type ItemType = {
   onClick: () => void;
   isActive?: boolean;
   isDisabled?: boolean;
+  displayNotificationBadge?: boolean;
 };
 
-const Item = ({ label, children, onClick, isActive, isDisabled }: ItemType): JSX.Element => {
+const Item = ({
+  label,
+  children,
+  onClick,
+  isActive,
+  isDisabled,
+  displayNotificationBadge,
+}: ItemType): JSX.Element => {
   const { isExpanded } = useContext(SideBarContext);
 
   const handleClick = () => {
@@ -95,6 +111,7 @@ const Item = ({ label, children, onClick, isActive, isDisabled }: ItemType): JSX
       >
         <ItemLabel variant="paragraph">{label}</ItemLabel>
       </TransitionInOut>
+      {displayNotificationBadge && <Badge />}
     </ItemWrapper>
   );
 };


### PR DESCRIPTION
In order to integrate the rebranding of the Navigation sidebar and header ([LL-7758]) into Ledger Live, a few adaptations had to take place into the library:
* Make content props of the Header optional
* Add an optional notification badge in the sidebar items

[LL-7758]: https://ledgerhq.atlassian.net/browse/LL-7758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ