### PR TITLE
LLD/React - Text component - Missing styles/variants + Story with all combinations from design system

### DIFF
--- a/packages/react/src/components/asorted/Text/Text.stories.tsx
+++ b/packages/react/src/components/asorted/Text/Text.stories.tsx
@@ -7,7 +7,7 @@ const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4", "h5"];
 
 const mainVariants: TextVariants[] = [
   "large",
-  // "largeLineHeight", // TODO: implement
+  "largeLineHeight",
   "body",
   "bodyLineHeight",
   "paragraph",

--- a/packages/react/src/components/asorted/Text/Text.stories.tsx
+++ b/packages/react/src/components/asorted/Text/Text.stories.tsx
@@ -22,10 +22,8 @@ const subtitleVariants: TextVariants[] = ["subtitle"];
 
 const variants: TextVariants[] = [...headerVariants, ...mainVariants, ...subtitleVariants];
 
-const isInCategory = (variant: TextVariants, variantsArray: TextVariants[]): boolean =>
-  variantsArray.includes(variant);
 const makeIsInCategory = (variantsArray: TextVariants[]) => (variant: TextVariants) =>
-  isInCategory(variant, variantsArray);
+  variantsArray.includes(variant);
 const isHeader = makeIsInCategory(headerVariants);
 const isSubtitle = makeIsInCategory(subtitleVariants);
 

--- a/packages/react/src/components/asorted/Text/Text.stories.tsx
+++ b/packages/react/src/components/asorted/Text/Text.stories.tsx
@@ -1,44 +1,51 @@
 import React from "react";
 import Text, { TextProps } from "./index";
+import Flex from "../../layout/Flex";
+import { TextVariants } from "../../../styles/theme";
+
+const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4", "h5"];
+
+const mainVariants: TextVariants[] = [
+  "large",
+  // "largeLineHeight", // TODO: implement
+  "body",
+  "bodyLineHeight",
+  "paragraph",
+  "paragraphLineHeight",
+  "small",
+  "extraSmall",
+  "tiny",
+  "micro",
+];
+
+const subtitleVariants: TextVariants[] = ["subtitle"];
+
+const variants: TextVariants[] = [...headerVariants, ...mainVariants, ...subtitleVariants];
+
+const isInCategory = (variant: TextVariants, variantsArray: TextVariants[]): boolean =>
+  variantsArray.includes(variant);
+const makeIsInCategory = (variantsArray: TextVariants[]) => (variant: TextVariants) =>
+  isInCategory(variant, variantsArray);
+const isHeader = makeIsInCategory(headerVariants);
+const isSubtitle = makeIsInCategory(subtitleVariants);
+
+const mainFontWeights = ["medium", "semiBold", "bold"];
+
+const fontWeights = [undefined, "extraLight", "light", "regular", ...mainFontWeights, "extraBold"];
+
 export default {
   title: "Asorted/Typography/Text",
   component: Text,
   parameters: { actions: { argTypesRegex: false } },
   argTypes: {
     variant: {
-      options: [
-        undefined,
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "large",
-        "body",
-        "bodyLineHeight",
-        "paragraph",
-        "paragraphLineHeight",
-        "small",
-        "extraSmall",
-        "tiny",
-        "micro",
-        "subtitle",
-      ],
+      options: [undefined, ...variants],
       control: {
         type: "radio",
       },
     },
     fontWeight: {
-      options: [
-        undefined,
-        "medium",
-        "extraLight",
-        "light",
-        "regular",
-        "semiBold",
-        "bold",
-        "extraBold",
-      ],
+      options: [undefined, ...fontWeights],
       control: {
         type: "radio",
       },
@@ -48,6 +55,45 @@ export default {
     },
   },
 };
+
+export const MainCombinations = (() => {
+  return (
+    <Flex flexDirection="column">
+      {variants.map((variant) => {
+        const fontWeightsToShow: string[] = isHeader(variant)
+          ? ["medium"]
+          : isSubtitle(variant)
+          ? ["semiBold"]
+          : mainFontWeights;
+        const decorationsToShow: string[] =
+          isHeader(variant) || isSubtitle(variant) ? ["none"] : ["none", "underline"];
+        const width = isHeader(variant) ? undefined : "200px";
+        return (
+          <Flex flexDirection="row" style={{ height: "100px" }}>
+            <div style={{ minWidth: 250 }}>
+              <Text variant="small" color="palette.neutral.c90">
+                variant="{variant}"
+              </Text>
+              <br />
+              <Text variant="tiny" color="palette.neutral.c70">
+                fontWeights: {JSON.stringify(fontWeightsToShow)}
+              </Text>
+            </div>
+            {fontWeightsToShow.flatMap((fontWeight) =>
+              decorationsToShow.map((textDecorationLine) => (
+                <div style={{ width, marginRight: "100px" }}>
+                  <Text variant={variant} fontWeight={fontWeight} style={{ textDecorationLine }}>
+                    Lend stablecoins to the Compound protocol...
+                  </Text>
+                </div>
+              )),
+            )}
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+}).bind({});
 
 const Template = (args: TextProps & { content: string }) => <Text {...args}>{args.content}</Text>;
 

--- a/packages/react/src/components/asorted/Text/Text.stories.tsx
+++ b/packages/react/src/components/asorted/Text/Text.stories.tsx
@@ -54,7 +54,7 @@ export default {
   },
 };
 
-export const MainCombinations = (() => {
+export const Overview = (() => {
   return (
     <Flex flexDirection="column">
       {variants.map((variant) => {

--- a/packages/react/src/components/asorted/Text/styles.ts
+++ b/packages/react/src/components/asorted/Text/styles.ts
@@ -63,7 +63,7 @@ export const textVariantStyle: Record<
   TextVariants,
   {
     fontFamily: string;
-    lineHeight?: string;
+    lineHeight?: string | number;
     fontWeight?: number;
     "text-transform"?: string;
   }
@@ -98,21 +98,21 @@ export const textVariantStyle: Record<
   },
   largeLineHeight: {
     fontFamily: "Inter",
-    lineHeight: "170%",
+    lineHeight: 1.7,
   },
   body: {
     fontFamily: "Inter",
   },
   bodyLineHeight: {
     fontFamily: "Inter",
-    lineHeight: "170%",
+    lineHeight: 1.7,
   },
   paragraph: {
     fontFamily: "Inter",
   },
   paragraphLineHeight: {
     fontFamily: "Inter",
-    lineHeight: "170%",
+    lineHeight: 1.7,
   },
   small: {
     fontFamily: "Inter",

--- a/packages/react/src/components/asorted/Text/styles.ts
+++ b/packages/react/src/components/asorted/Text/styles.ts
@@ -84,7 +84,7 @@ export const textVariantStyle: Record<
     "text-transform": "uppercase",
   },
   h4: {
-    fontFamily: "Inter",
+    fontFamily: "Alpha",
     fontWeight: 500,
     "text-transform": "uppercase",
   },

--- a/packages/react/src/components/asorted/Text/styles.ts
+++ b/packages/react/src/components/asorted/Text/styles.ts
@@ -65,44 +65,54 @@ export const textVariantStyle: Record<
     fontFamily: string;
     lineHeight?: string;
     fontWeight?: number;
+    "text-transform"?: string;
   }
 > = {
   h1: {
     fontFamily: "Alpha",
     fontWeight: 500,
+    "text-transform": "uppercase",
   },
   h2: {
     fontFamily: "Alpha",
     fontWeight: 500,
+    "text-transform": "uppercase",
   },
   h3: {
     fontFamily: "Alpha",
     fontWeight: 500,
+    "text-transform": "uppercase",
   },
   h4: {
     fontFamily: "Inter",
     fontWeight: 500,
+    "text-transform": "uppercase",
   },
   h5: {
     fontFamily: "Alpha",
     fontWeight: 500,
+    "text-transform": "uppercase",
   },
   large: {
     fontFamily: "Inter",
+  },
+  largeLineHeight: {
+    fontFamily: "Inter",
+    lineHeight: "170%",
   },
   body: {
     fontFamily: "Inter",
   },
   bodyLineHeight: {
     fontFamily: "Inter",
-    lineHeight: "20px",
+    lineHeight: "170%",
   },
   paragraph: {
     fontFamily: "Inter",
   },
   paragraphLineHeight: {
     fontFamily: "Inter",
-    lineHeight: "18px",
+    lineHeight: "170%",
   },
   small: {
     fontFamily: "Inter",
@@ -110,14 +120,15 @@ export const textVariantStyle: Record<
   extraSmall: {
     fontFamily: "Inter",
   },
-  subtitle: {
-    fontFamily: "Inter",
-    fontWeight: 600,
-  },
   tiny: {
     fontFamily: "Inter",
   },
   micro: {
     fontFamily: "Inter",
+  },
+  subtitle: {
+    fontFamily: "Inter",
+    fontWeight: 600,
+    "text-transform": "uppercase",
   },
 };

--- a/packages/react/src/styles/theme.ts
+++ b/packages/react/src/styles/theme.ts
@@ -15,6 +15,7 @@ export type TextVariants =
   | "h4"
   | "h5"
   | "large"
+  | "largeLineHeight"
   | "body"
   | "bodyLineHeight"
   | "paragraph"
@@ -46,6 +47,7 @@ export const fontSizes = [8, 10, 11, 12, 13, 14, 16, 20, 24, 28, 32, 36] as Them
   fontSizes.h2,
   fontSizes.h1,
 ] = fontSizes;
+fontSizes.largeLineHeight = fontSizes.large;
 fontSizes.bodyLineHeight = fontSizes.body;
 fontSizes.paragraphLineHeight = fontSizes.paragraph;
 fontSizes.subtitle = fontSizes.extraSmall;


### PR DESCRIPTION
- Adds a story "main combinations" showing all the combinations of props `variant`, `fontWeight` and style `textDecorationLine` as displayed in the [LLD/Library Figma - Typescale](https://www.figma.com/file/WXCEmRMwW47ELrFonzPTGg/LLD-%2F-Library?node-id=502%3A728)
- Updates line heights values
- Adds "largeLineHeight" variant
- Adds uppercase for some variants (h1..h5, subtitle)

https://user-images.githubusercontent.com/91890529/140962927-50960e83-327a-40df-b21b-998efd15a549.mov




