### PR TITLE
Input serializers

### DIFF
--- a/packages/native/src/components/Form/Input/BaseInput/index.tsx
+++ b/packages/native/src/components/Form/Input/BaseInput/index.tsx
@@ -1,17 +1,38 @@
-import React from "react";
+import React, { useMemo, useCallback } from "react";
 import { View, TextInputProps, ColorValue } from "react-native";
 import styled, { css } from "styled-components/native";
 import Text from "../../../Text";
 import FlexBox from "../../../Layout/Flex";
 
-export type CommonProps = TextInputProps & {
+export type CommonProps<T = string> = Omit<
+  TextInputProps,
+  "value" | "onChange"
+> & {
+  value: T;
+  onChange: (value: T) => void;
   disabled?: boolean;
   error?: string;
+  /**
+   * A function can be provided to serialize a value of any type to a string.
+   *
+   * This can be useful to wrap the `<BaseInput />` component (which expects a string)
+   * and create higher-level components that will automatically perform the input/output
+   * conversion to other types.
+   *
+   * *A serializer function should always be used in conjunction with a deserializer function.*
+   */
+  serialize?: (value: T) => string;
+  /**
+   * A deserializer can be provided to convert the html input value from a string to any other type.
+   *
+   * *A deserializer function should always be used in conjunction with a serializer function.*
+   */
+  deserialize?: (value: string) => T;
 };
 
-export type InputProps = CommonProps & {
-  renderLeft?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
-  renderRight?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
+export type InputProps<T = string> = CommonProps<T> & {
+  renderLeft?: ((props: CommonProps<T>) => React.ReactNode) | React.ReactNode;
+  renderRight?: ((props: CommonProps<T>) => React.ReactNode) | React.ReactNode;
 };
 
 const InputContainer = styled.View<Partial<CommonProps> & { focus?: boolean }>`
@@ -83,9 +104,33 @@ export const InputRenderRightContainer = styled(FlexBox).attrs(() => ({
   pr: "16px",
 }))``;
 
-export default function Input(props: InputProps): JSX.Element {
-  const { value, disabled, error, renderLeft, renderRight, ...textInputProps } =
-    props;
+// Yes, this is dirty. If you can figure out a better way please change the code :).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const IDENTITY = (_: any): any => _;
+
+export default function Input<T = string>(props: InputProps<T>): JSX.Element {
+  const {
+    value,
+    onChange,
+    onChangeText,
+    disabled,
+    error,
+    renderLeft,
+    renderRight,
+    serialize = IDENTITY,
+    deserialize = IDENTITY,
+    ...textInputProps
+  } = props;
+
+  const inputValue = useMemo(() => serialize(value), [serialize, value]);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      onChange(deserialize(value));
+      if (onChangeText) onChangeText(value);
+    },
+    [onChange, onChangeText, deserialize]
+  );
 
   const [focus, setFocus] = React.useState(false);
 
@@ -95,10 +140,11 @@ export default function Input(props: InputProps): JSX.Element {
         {typeof renderLeft === "function" ? renderLeft(props) : renderLeft}
         <BaseInput
           {...textInputProps}
+          value={inputValue}
+          onChangeText={handleChange}
           editable={!disabled}
           disabled={disabled}
           error={error}
-          value={value}
           onFocus={() => setFocus(true)}
           onBlur={() => setFocus(false)}
         />

--- a/packages/native/src/components/Form/Input/BaseInput/index.tsx
+++ b/packages/native/src/components/Form/Input/BaseInput/index.tsx
@@ -4,14 +4,17 @@ import styled, { css } from "styled-components/native";
 import Text from "../../../Text";
 import FlexBox from "../../../Layout/Flex";
 
-export type CommonProps<T = string> = Omit<
-  TextInputProps,
-  "value" | "onChange"
-> & {
-  value: T;
-  onChange: (value: T) => void;
+export type CommonProps = TextInputProps & {
   disabled?: boolean;
   error?: string;
+};
+
+export type InputProps<T = string> = Omit<CommonProps, "value" | "onChange"> & {
+  renderLeft?: ((props: InputProps<T>) => React.ReactNode) | React.ReactNode;
+  renderRight?: ((props: InputProps<T>) => React.ReactNode) | React.ReactNode;
+  value: T;
+  onChange?: (value: T) => void;
+  onChangeEvent?: TextInputProps["onChange"];
   /**
    * A function can be provided to serialize a value of any type to a string.
    *
@@ -28,11 +31,6 @@ export type CommonProps<T = string> = Omit<
    * *A deserializer function should always be used in conjunction with a serializer function.*
    */
   deserialize?: (value: string) => T;
-};
-
-export type InputProps<T = string> = CommonProps<T> & {
-  renderLeft?: ((props: CommonProps<T>) => React.ReactNode) | React.ReactNode;
-  renderRight?: ((props: CommonProps<T>) => React.ReactNode) | React.ReactNode;
 };
 
 const InputContainer = styled.View<Partial<CommonProps> & { focus?: boolean }>`
@@ -113,6 +111,7 @@ export default function Input<T = string>(props: InputProps<T>): JSX.Element {
     value,
     onChange,
     onChangeText,
+    onChangeEvent,
     disabled,
     error,
     renderLeft,
@@ -126,8 +125,8 @@ export default function Input<T = string>(props: InputProps<T>): JSX.Element {
 
   const handleChange = useCallback(
     (value: string) => {
-      onChange(deserialize(value));
-      if (onChangeText) onChangeText(value);
+      onChange && onChange(deserialize(value));
+      onChangeText && onChangeText(value);
     },
     [onChange, onChangeText, deserialize]
   );
@@ -141,6 +140,7 @@ export default function Input<T = string>(props: InputProps<T>): JSX.Element {
         <BaseInput
           {...textInputProps}
           value={inputValue}
+          onChange={onChangeEvent}
           onChangeText={handleChange}
           editable={!disabled}
           disabled={disabled}

--- a/packages/native/src/components/Form/Input/NumberInput/index.tsx
+++ b/packages/native/src/components/Form/Input/NumberInput/index.tsx
@@ -24,19 +24,32 @@ const PercentButton = styled(TouchableOpacity)<{ active?: boolean }>`
   align-items: center;
 `;
 
+function serialize(value?: number) {
+  return value ? "" + value : "";
+}
+function deserialize(value: string) {
+  try {
+    return parseFloat(value);
+  } catch (error) {
+    return undefined;
+  }
+}
+
 export default function NumberInput({
   onPercentClick,
   max,
   value,
   disabled,
   ...inputProps
-}: InputProps & {
+}: InputProps<number | undefined> & {
   onPercentClick: (percent: number) => void;
   min?: number;
   max?: number;
 }): JSX.Element {
   return (
     <Input
+      serialize={serialize}
+      deserialize={deserialize}
       {...inputProps}
       value={value}
       disabled={disabled}

--- a/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/BaseInput.stories.tsx
@@ -7,16 +7,18 @@ import Input, {
   InputRenderRightContainer,
   CommonProps,
 } from "../../../../src/components/Form/Input/BaseInput";
+import Flex from "../../../../src/components/Layout/Flex";
+import Text from "../../../../src/components/Text";
 
 const BaseInputStory = () => {
   const [value, setValue] = useState("");
 
-  const onChangeText = (value: string) => setValue(value);
+  const onChange = (value: string) => setValue(value);
 
   return (
     <Input
       value={value}
-      onChangeText={onChangeText}
+      onChange={onChange}
       placeholder={"Placeholder"}
       disabled={boolean("disabled", false)}
       error={text("error", "")}
@@ -29,7 +31,7 @@ const BaseInputRenderSideExempleStory = () => {
   const [disabled, setDisabled] = useState(false);
   const [error, setError] = React.useState<string | undefined>();
 
-  const onChangeText = (value: string) => setValue(value);
+  const onChange = (value: string) => setValue(value);
 
   const renderLeft = (
     <InputRenderLeftContainer>
@@ -52,7 +54,7 @@ const BaseInputRenderSideExempleStory = () => {
   return (
     <Input
       value={value}
-      onChangeText={onChangeText}
+      onChange={onChange}
       renderLeft={renderLeft}
       renderRight={renderRight}
       placeholder={"test"}
@@ -62,8 +64,42 @@ const BaseInputRenderSideExempleStory = () => {
   );
 };
 
+function serialize(value: string) {
+  return value.split("").join(".");
+}
+
+function deserialize(value: string) {
+  return value.replace(/\./g, "");
+}
+
+const CustomSerializer = (): JSX.Element => {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <>
+      <Input
+        value={value}
+        onChange={setValue}
+        serialize={serialize}
+        deserialize={deserialize}
+        placeholder={"Placeholder"}
+      />
+      <Flex
+        flexDirection="row"
+        alignItems="baseline"
+        m={8}
+        alignSelf="flex-start"
+      >
+        <Text variant="large">Value: </Text>
+        <Text>{value}</Text>
+      </Flex>
+    </>
+  );
+};
+
 storiesOf((story) =>
   story("Form/Input/BaseInput", module)
     .add("BaseInput", BaseInputStory)
     .add("RenderSideExemple", BaseInputRenderSideExempleStory)
+    .add("Custom Serializer", CustomSerializer)
 );

--- a/packages/native/storybook/stories/Form/Input/LegendInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/LegendInput.stories.tsx
@@ -12,7 +12,7 @@ const LegendInputStory = (): JSX.Element => {
     <LegendInput
       legend={text("label", "Ledger")}
       value={value}
-      onChangeText={onChange}
+      onChange={onChange}
       placeholder={"Placeholder"}
     />
   );

--- a/packages/native/storybook/stories/Form/Input/NumberInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/NumberInput.stories.tsx
@@ -5,19 +5,16 @@ import { number } from "@storybook/addon-knobs";
 
 const NumberInputStory = () => {
   const [value, setValue] = React.useState(24.42);
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  const max = number("max", undefined as any);
-  const min = number("min", undefined as any);
-  /* esline-enable @typescript-eslint/no-explicit-any */
+  const max = number("max", 349);
+  const min = number("min", 0);
 
   // FixMe: Naive implementation, only for story demo
-  const onChange = (value: string) => {
-    let nb = parseInt(value);
+  const onChange = (nb?: number) => {
     if (nb) {
       if (max && nb > max) nb = max;
       if (min && nb < min) nb = min;
+      setValue(nb);
     }
-    setValue(nb);
   };
 
   const onPercentClick = (percent: number) => {
@@ -26,8 +23,8 @@ const NumberInputStory = () => {
 
   return (
     <NumberInput
-      value={value.toString()}
-      onChangeText={onChange}
+      value={value}
+      onChange={onChange}
       onPercentClick={onPercentClick}
       placeholder={"Placeholder"}
       min={min}

--- a/packages/native/storybook/stories/Form/Input/QrCodeInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/QrCodeInput.stories.tsx
@@ -10,7 +10,7 @@ const QrCodeInputStory = (): JSX.Element => {
   return (
     <QrCodeInput
       value={value}
-      onChangeText={onChange}
+      onChange={onChange}
       placeholder={"Placeholder"}
     />
   );

--- a/packages/native/storybook/stories/Form/Input/SearchInput.stories.tsx
+++ b/packages/native/storybook/stories/Form/Input/SearchInput.stories.tsx
@@ -10,7 +10,7 @@ const SearchInputStory = (): JSX.Element => {
   return (
     <SearchInput
       value={value}
-      onChangeText={onChange}
+      onChange={onChange}
       placeholder={"Placeholder"}
     />
   );

--- a/packages/native/tsconfig.json
+++ b/packages/native/tsconfig.json
@@ -10,6 +10,10 @@
   },
   "include": ["src/**/*", "storybook/**/*"],
   "exclude": [
+    ".expo",
+    ".expo-shared",
+    "scripts",
+    "assets",
     "node_modules",
     "babel.config.js",
     "metro.config.js",

--- a/packages/react/src/components/form/BaseInput/Input.stories.tsx
+++ b/packages/react/src/components/form/BaseInput/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Button from "../../cta/Button";
 import Input, { InputProps, InputRenderLeftContainer, InputRenderRightContainer } from "./index";
+import { Flex, Text } from "../..";
 
 export default {
   title: "Form/Input/Base",
@@ -65,5 +66,34 @@ export const RenderSideExemple = (): JSX.Element => {
       renderRight={renderRight}
       placeholder={"test"}
     />
+  );
+};
+
+function serialize(value: string) {
+  return value.split("").join(".");
+}
+
+function deserialize(value: string) {
+  return value.replace(/\./g, "");
+}
+
+export const CustomSerializer = (args: InputProps): JSX.Element => {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <Flex flexDirection="column" rowGap={8}>
+      <Input
+        {...args}
+        value={value}
+        onChange={setValue}
+        serialize={serialize}
+        deserialize={deserialize}
+        placeholder={"Placeholder"}
+      />
+      <span>
+        <Text variant="large">Value: </Text>
+        {value}
+      </span>
+    </Flex>
   );
 };

--- a/packages/react/src/components/form/BaseInput/index.tsx
+++ b/packages/react/src/components/form/BaseInput/index.tsx
@@ -7,18 +7,19 @@ import { rgba } from "../../../styles/helpers";
 
 type ValueType = HTMLInputElement["value"];
 
-export type CommonProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> &
+export type CommonProps = InputHTMLAttributes<HTMLInputElement> &
   TypographyProps & {
     disabled?: boolean;
     error?: string;
     warning?: string;
   };
 
-export type InputProps<T = ValueType> = CommonProps & {
+export type InputProps<T = ValueType> = Omit<CommonProps, "value" | "onChange"> & {
   value: T;
-  onChange: (value: T) => void;
-  renderLeft?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
-  renderRight?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
+  onChange?: (value: T) => void;
+  onChangeEvent?: InputHTMLAttributes<HTMLInputElement>["onChange"];
+  renderLeft?: ((props: InputProps<T>) => React.ReactNode) | React.ReactNode;
+  renderRight?: ((props: InputProps<T>) => React.ReactNode) | React.ReactNode;
   unwrapped?: boolean;
   containerProps?: InputContainerProps;
   /**
@@ -162,6 +163,7 @@ function Input<T = ValueType>(
     error,
     warning,
     onChange,
+    onChangeEvent,
     renderLeft,
     renderRight,
     unwrapped,
@@ -174,8 +176,11 @@ function Input<T = ValueType>(
   const inputValue = useMemo(() => serialize(value), [serialize, value]);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(deserialize(e.target.value)),
-    [onChange, deserialize],
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange && onChange(deserialize(e.target.value));
+      onChangeEvent && onChangeEvent(e);
+    },
+    [onChange, onChangeEvent, deserialize],
   );
 
   const inner = (

--- a/packages/react/src/components/form/BaseInput/index.tsx
+++ b/packages/react/src/components/form/BaseInput/index.tsx
@@ -1,23 +1,42 @@
 import styled, { css } from "styled-components";
 import { typography, TypographyProps } from "styled-system";
-import React, { InputHTMLAttributes, useCallback } from "react";
+import React, { InputHTMLAttributes, useState, useMemo, useCallback } from "react";
 import FlexBox from "../../layout/Flex";
 import Text from "../../asorted/Text";
 import { rgba } from "../../../styles/helpers";
 
-export type CommonProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> &
+type ValueType = HTMLInputElement["value"];
+
+export type CommonProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> &
   TypographyProps & {
     disabled?: boolean;
     error?: string;
     warning?: string;
   };
 
-export type InputProps = CommonProps & {
-  onChange: (e: string) => void;
+export type InputProps<T = ValueType> = CommonProps & {
+  value: T;
+  onChange: (value: T) => void;
   renderLeft?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
   renderRight?: ((props: CommonProps) => React.ReactNode) | React.ReactNode;
   unwrapped?: boolean;
   containerProps?: InputContainerProps;
+  /**
+   * A function can be provided to serialize a value of any type to a string.
+   *
+   * This can be useful to wrap the `<BaseInput />` component (which expects a string)
+   * and create higher-level components that will automatically perform the input/output
+   * conversion to other types.
+   *
+   * *A serializer function should always be used in conjunction with a deserializer function.*
+   */
+  serialize?: (value: T) => ValueType;
+  /**
+   * A deserializer can be provided to convert the html input value from a string to any other type.
+   *
+   * *A deserializer function should always be used in conjunction with a serializer function.*
+   */
+  deserialize?: (value: ValueType) => T;
 };
 
 export type InputContainerProps = React.ComponentProps<typeof InputContainer>;
@@ -129,7 +148,14 @@ export const InputRenderRightContainer = styled(FlexBox).attrs(() => ({
   pr: "16px",
 }))``;
 
-function Input(props: InputProps, ref: React.ForwardedRef<HTMLInputElement>): JSX.Element {
+// Yes, this is dirty. If you can figure out a better way please change the code :).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const IDENTITY = (_: any): any => _;
+
+function Input<T = ValueType>(
+  props: InputProps<T>,
+  ref: React.ForwardedRef<HTMLInputElement>,
+): JSX.Element {
   const {
     value,
     disabled,
@@ -140,13 +166,16 @@ function Input(props: InputProps, ref: React.ForwardedRef<HTMLInputElement>): JS
     renderRight,
     unwrapped,
     containerProps,
+    serialize = IDENTITY,
+    deserialize = IDENTITY,
     ...htmlInputProps
   } = props;
-  const [focus, setFocus] = React.useState(false);
+  const [focus, setFocus] = useState(false);
+  const inputValue = useMemo(() => serialize(value), [serialize, value]);
 
   const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
-    [onChange],
+    (e: React.ChangeEvent<HTMLInputElement>) => onChange(deserialize(e.target.value)),
+    [onChange, deserialize],
   );
 
   const inner = (
@@ -159,7 +188,7 @@ function Input(props: InputProps, ref: React.ForwardedRef<HTMLInputElement>): JS
         error={error}
         warning={warning}
         onChange={handleChange}
-        value={value}
+        value={inputValue}
         onFocus={(event) => {
           setFocus(true);
           htmlInputProps.onFocus && htmlInputProps.onFocus(event);
@@ -202,4 +231,6 @@ function Input(props: InputProps, ref: React.ForwardedRef<HTMLInputElement>): JS
   );
 }
 
-export default React.forwardRef(Input);
+export default React.forwardRef(Input) as <T>(
+  props: InputProps<T> & { ref?: React.ForwardedRef<HTMLInputElement> },
+) => ReturnType<typeof Input>;

--- a/packages/react/src/components/form/NumberInput/Input.stories.tsx
+++ b/packages/react/src/components/form/NumberInput/Input.stories.tsx
@@ -28,16 +28,14 @@ export const Number = ({
   min,
   max,
   ...otherArgs
-}: InputProps & { max: number; min: number }): JSX.Element => {
+}: InputProps<number | undefined> & { max: number; min: number }): JSX.Element => {
   const [value, setValue] = React.useState(24.42);
 
-  const onChange = (val: string) => {
-    if (val) {
-      let value = parseFloat(val);
-      if (value > max) value = max;
-      if (value < min) value = min;
-      setValue(value);
-    }
+  const onChange = (value?: number) => {
+    if (!value) return setValue(0);
+    if (value > max) value = max;
+    if (value < min) value = min;
+    setValue(value);
   };
 
   const onPercentClick = (percent: number) => {

--- a/packages/react/src/components/form/NumberInput/index.tsx
+++ b/packages/react/src/components/form/NumberInput/index.tsx
@@ -24,22 +24,35 @@ const MaxButton = styled.button<{ active?: boolean }>`
   }
 `;
 
+function serialize(value?: number) {
+  return value ? "" + value : "";
+}
+function deserialize(value: string) {
+  try {
+    return parseFloat(value);
+  } catch (error) {
+    return undefined;
+  }
+}
+
 export default function NumberInput({
+  value,
   onPercentClick,
   max,
-  value,
   disabled,
   ...inputProps
-}: InputProps & {
+}: InputProps<number | undefined> & {
   onPercentClick: (percent: number) => void;
 }): JSX.Element {
   return (
     <Input
+      serialize={serialize}
+      deserialize={deserialize}
       {...inputProps}
+      type={"number"}
       value={value}
       max={max}
       disabled={disabled}
-      type={"number"}
       renderRight={
         <FlexBox alignItems={"center"} justifyContent={"center"} py={"3px"} mr={"8px"}>
           {[0.25, 0.5, 0.75, 1].map((percent) => (


### PR DESCRIPTION
#### Adds serializer / deserializer props to the `<BaseInput />` component allowing non-string input/output types 

🔥 This is breaking because: 
- (react): the `onChange` callback now expects a number for `NumberInput`
- ~(native): the onChange prop must now be used instead of onChangeText~

#### Example

To convert input/output to a floating number:
*(this is actually the new `<NumberInput />` behaviour)*

```js
function serialize(value?: number) {
  return value ? "" + value : "";
}

function deserialize(value: string) {
  try {
    return parseFloat(value);
  } catch (error) {
    return undefined;
  }
}
```

#### Jira

[LL-8078]
[LL-8079]


[LL-8078]: https://ledgerhq.atlassian.net/browse/LL-8078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LL-8079]: https://ledgerhq.atlassian.net/browse/LL-8079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ