### PR TITLE
feat(native): add selectable list component

### DIFF
--- a/packages/native/src/components/Form/SelectableList.tsx
+++ b/packages/native/src/components/Form/SelectableList.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { GestureResponderEvent, TouchableOpacity } from "react-native";
+import styled from "styled-components/native";
+import { border, BorderProps } from "styled-system";
+import Flex from "../Layout/Flex";
+import { Text } from "../index";
+
+export type ElementProps<V> = React.PropsWithChildren<{
+  first?: boolean;
+  selected?: boolean;
+  value?: V;
+  onPress?: ((event: GestureResponderEvent) => void) | undefined;
+}>;
+
+const ElementContainer = styled(Flex).attrs({
+  accessible: true,
+  accessibilityRole: "radio",
+})<BorderProps>`
+  ${border}
+`;
+
+function Element<V>({
+  first,
+  value,
+  selected,
+  onPress,
+  children,
+}: ElementProps<V>) {
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <ElementContainer
+        p={6}
+        mt={first ? 0 : 4}
+        backgroundColor={
+          selected ? "palette.primary.c20" : "palette.neutral.c00"
+        }
+        border="1px solid"
+        borderColor={selected ? "palette.primary.c100" : "palette.neutral.c40"}
+        borderRadius={1}
+      >
+        <Text variant="large">{children || value}</Text>
+      </ElementContainer>
+    </TouchableOpacity>
+  );
+}
+
+export type Props<V> = React.PropsWithChildren<{
+  currentValue?: V;
+  onChange: (newValue: V) => void;
+}>;
+
+function SelectableList<V>({ currentValue, onChange, children }: Props<V>) {
+  return (
+    <Flex accessible accessibilityRole="radiogroup">
+      {React.Children.map(children, (child, index) => {
+        if (!React.isValidElement(child)) return null;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const casted = child as React.ReactElement<ElementProps<any>>;
+        return React.cloneElement(casted, {
+          first: index === 0,
+          onPress: () => onChange(casted?.props.value),
+          selected: casted?.props.value === currentValue,
+        });
+      })}
+    </Flex>
+  );
+}
+SelectableList.Element = Element;
+export default SelectableList;

--- a/packages/native/src/components/Form/index.ts
+++ b/packages/native/src/components/Form/index.ts
@@ -2,3 +2,4 @@ export { default as Checkbox } from "./Checkbox";
 export * from "./Input";
 export { default as Slider } from "./Slider";
 export { default as Switch } from "./Switch";
+export { default as SelectableList } from "./SelectableList";

--- a/packages/native/storybook/stories/Form/SelectableList.stories.tsx
+++ b/packages/native/storybook/stories/Form/SelectableList.stories.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { storiesOf } from "../storiesOf";
+import { Flex, SelectableList } from "../../../src";
+
+const description = `
+### A styled list of valued and selectable elements.
+
+Each element of the list has an associated value (_of any similar type - not necessarily strings_)
+and can be selected by pressing it.
+
+## Usage
+
+\`\`\`js
+
+import { SelectableList } from "@ledgerhq/native-ui"
+\`\`\`
+
+A \`SelectableList\` contains one or multiple \`SelectableList.Element\` components as children.
+
+
+\`\`\`js
+const [selectedValue, setSelectedValue] = React.useState()
+
+/* … */
+
+<SelectableList currentValue={selectedValue} onChange={setSelectedValue}>
+  <SelectableList.Element value={1}>One</SelectableList.Element>
+  <SelectableList.Element value={2}>Two</SelectableList.Element>
+  <SelectableList.Element value={3}>Three</SelectableList.Element>
+</SelectableList>
+\`\`\`
+`;
+
+const Story = () => {
+  const [selectedValue, setSelectedValue] = useState();
+
+  return (
+    <Flex alignSelf="stretch" p={4}>
+      <SelectableList currentValue={selectedValue} onChange={setSelectedValue}>
+        <SelectableList.Element value="en">English</SelectableList.Element>
+        <SelectableList.Element value="fr">French</SelectableList.Element>
+        <SelectableList.Element value="ru">Russian</SelectableList.Element>
+        <SelectableList.Element value="cz">Chinese</SelectableList.Element>
+        <SelectableList.Element value="sp">Spanish</SelectableList.Element>
+      </SelectableList>
+    </Flex>
+  );
+};
+
+storiesOf((story) =>
+  story("Form/SelectableList", module).add("SelectableList", Story, {
+    docs: {
+      title: "Selectable List",
+      description: {
+        component: description,
+      },
+    },
+  })
+);

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -30,3 +30,4 @@ import "./Layout/Table.stories";
 import "./Layout/Collapse/Accordion.stories";
 import "./Form/Slider/Slider.stories";
 import "./Chart/Chart.stories";
+import "./Form/SelectableList.stories";


### PR DESCRIPTION
#### Adds the mobile counterpart to the `Radio.ListElement` component

_This component is not defined in the core components Figma but is required to work on the onboarding._

https://user-images.githubusercontent.com/86958797/142256841-f30b76d3-9152-4a2d-ac44-3d75747dfb7c.mp4