### PR TITLE
LL-8213 Add chip style tabs component

### DIFF
--- a/packages/react/src/components/tabs/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/tabs/Chip/Chip.stories.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+
+import ChipTabs, { Props } from "./index";
+import Text from "../../asorted/Text";
+
+export default {
+  title: "Tabs/Chip",
+  component: ChipTabs,
+  argTypes: {
+    initialActiveIndex: {
+      control: { type: "number" },
+    },
+  },
+};
+
+const navItems = ["One", "Two", "Three", "Four", "Five"];
+
+function Sample({ children, ...args }: Props) {
+  const [activeIndex, setActiveIndex] = useState(args.initialActiveIndex);
+  return (
+    <div style={{ marginBottom: "10px" }}>
+      <div style={{ width: "100%" }}>
+        <ChipTabs {...args} onTabChange={setActiveIndex}>
+          {children}
+        </ChipTabs>
+      </div>
+      <Text variant="subtitle">Active index: {activeIndex}</Text>
+      <hr />
+    </div>
+  );
+}
+
+export const Chip = (args: Props): React.ReactNode[] =>
+  navItems.reduce<React.ReactNode[]>((acc, _, index) => {
+    const labels = [
+      navItems.slice(0, index + 1).map((label) => (
+        <Text color="inherit" variant="small">
+          {label}
+        </Text>
+      )),
+    ];
+    return [
+      ...acc,
+      <Sample {...args} key={index}>
+        {labels}
+      </Sample>,
+    ];
+  }, []);
+
+Chip.args = {
+  initialActiveIndex: 1,
+};

--- a/packages/react/src/components/tabs/Chip/index.tsx
+++ b/packages/react/src/components/tabs/Chip/index.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Flex from "../../layout/Flex";
+
+export type Props = React.PropsWithChildren<{
+  /**
+   * An optional callback that will be called when the active tab changes.
+   */
+  onTabChange?: (activeIndex: number) => void;
+  /**
+   * The tab index to mark as active when rendering for the first time.
+   * If omitted, then initially no tabs will be selected.
+   */
+  initialActiveIndex?: number;
+}>;
+type ItemProps = {
+  active: boolean;
+};
+
+const Item = styled(Flex).attrs({
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+})<ItemProps>`
+  cursor: pointer;
+  padding: 8px 12px 8px 12px;
+  border-radius: ${(p) => p.theme.radii[2]}px;
+  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  background-color: ${(p) => (p.active ? p.theme.colors.palette.primary.c30 : "unset")};
+`;
+
+export default function BarTabs({ children, onTabChange, initialActiveIndex }: Props): JSX.Element {
+  const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+  return (
+    <Flex justifyContent="space-between" flex={1} columnGap={5}>
+      {React.Children.toArray(children).map((child, index) => (
+        <Item
+          key={index}
+          active={index === activeIndex}
+          onClick={() => {
+            setActiveIndex(index);
+            onTabChange && onTabChange(index);
+          }}
+        >
+          {child}
+        </Item>
+      ))}
+    </Flex>
+  );
+}

--- a/packages/react/src/components/tabs/index.ts
+++ b/packages/react/src/components/tabs/index.ts
@@ -1,3 +1,4 @@
 export { default as Bar } from "./Bar";
 export { default as Pill } from "./Pill";
 export { default as Tabs } from "./Tabs";
+export { default as Chip } from "./Chip";


### PR DESCRIPTION
A component was missing for the Settings page in ledger live (the chip-style tabs component).
This PR adds this component
![chip-tab](https://user-images.githubusercontent.com/91940736/143054623-54a32367-502e-4f8e-9f52-eaa3fb35c42f.gif)

