### PR TITLE
Bypass the theme .palette colors prefix

### DIFF
--- a/examples/next.js/pages/index.js
+++ b/examples/next.js/pages/index.js
@@ -9,9 +9,9 @@ export default function Home({ isLight, setPalette }) {
       justifyContent="center"
       rowGap={12}
       style={{ height: "100vh" }}
-      backgroundColor="palette.neutral.c00"
+      backgroundColor="neutral.c00"
     >
-      <Text color="palette.neutral.c100">
+      <Text color="neutral.c100">
         <Logos.LedgerLiveRegular />
       </Text>
       <Text variant="h1">Hello, world!</Text>

--- a/examples/webpack.js/src/App.js
+++ b/examples/webpack.js/src/App.js
@@ -19,9 +19,9 @@ export function App({ isLight, setPalette }) {
         justifyContent="center"
         rowGap={12}
         style={{ height: "100vh" }}
-        backgroundColor="palette.neutral.c00"
+        backgroundColor="neutral.c00"
       >
-        <Text color="palette.neutral.c100">
+        <Text color="neutral.c100">
           <Logos.LedgerLiveRegular />
         </Text>
         <Text variant="h1">Hello, world!</Text>

--- a/packages/icons/scripts/buildReactIcons.js
+++ b/packages/icons/scripts/buildReactIcons.js
@@ -89,7 +89,7 @@ function reactNativeTemplate(
 
     ${interfaces}
 
-    function ${componentName} ({ size = 16, color = "palette.neutral.c100" }: Props): JSX.Element {
+    function ${componentName} ({ size = 16, color = "neutral.c100" }: Props): JSX.Element {
       return ${jsx};
     }
 

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -62,7 +62,7 @@ import { Flex, Text } from "@ledgerhq/native-ui";
 function Hello() {
   return (
     <Flex flexDirection="column" alignItems="center">
-      <Text variant="h1" color="palette.neutral.c100">
+      <Text variant="h1" color="neutral.c100">
         Hello, world!
       </Text>
     </Flex>
@@ -133,7 +133,7 @@ import { useFonts } from "expo-font";
 
 function Logo() {
   const theme = useTheme();
-  return <Logos.LedgerLiveRegular color={theme.colors.palette.neutral.c100} />;
+  return <Logos.LedgerLiveRegular color={theme.colors.neutral.c100} />;
 }
 
 function FontProvider({ children }) {
@@ -163,10 +163,10 @@ export default function App() {
           justifyContent="center"
           alignItems="center"
           flexDirection="column"
-          backgroundColor="palette.neutral.c00"
+          backgroundColor="neutral.c00"
         >
           <Logo />
-          <Text variant="h2" color="palette.neutral.c100" my={10}>
+          <Text variant="h2" color="neutral.c100" my={10}>
             Hello, world!
           </Text>
           <Switch
@@ -190,7 +190,7 @@ import { useTheme } from "styled-components/native";
 
 function Logo() {
   const theme = useTheme();
-  return <Logos.LedgerLiveRegular color={theme.colors.palette.neutral.c100} />;
+  return <Logos.LedgerLiveRegular color={theme.colors.neutral.c100} />;
 }
 
 export default function App() {
@@ -205,10 +205,10 @@ export default function App() {
         justifyContent="center"
         alignItems="center"
         flexDirection="column"
-        backgroundColor="palette.neutral.c00"
+        backgroundColor="neutral.c00"
       >
         <Logo />
-        <Text variant="h2" color="palette.neutral.c100" my={10}>
+        <Text variant="h2" color="neutral.c100" my={10}>
           Hello, world!
         </Text>
         <Switch

--- a/packages/native/src/components/Form/Checkbox/index.tsx
+++ b/packages/native/src/components/Form/Checkbox/index.tsx
@@ -19,11 +19,11 @@ const Square = styled(Flex).attrs({
   width: 18px;
   height: 18px;
   border-radius: 4px;
-  color: ${({ theme }) => theme.colors.palette.neutral.c00};
+  color: ${({ theme }) => theme.colors.neutral.c00};
   ${({ checked, theme }) =>
     checked
-      ? `background-color: ${theme.colors.palette.primary.c90};`
-      : `border: 1px solid ${theme.colors.palette.neutral.c50};`}
+      ? `background-color: ${theme.colors.primary.c90};`
+      : `border: 1px solid ${theme.colors.neutral.c50};`}
 `;
 
 const Checkbox = ({
@@ -38,16 +38,12 @@ const Checkbox = ({
     <Pressable onPress={onChange} disabled={disabled}>
       <Flex flexDirection="row" alignItems="center">
         <Square checked={checked}>
-          {checked ? (
-            <CheckAlone size={13} color={colors.palette.neutral.c00} />
-          ) : null}
+          {checked ? <CheckAlone size={13} color={colors.neutral.c00} /> : null}
         </Square>
         {label ? (
           <Text
             variant="body"
-            color={
-              checked ? colors.palette.primary.c90 : colors.palette.neutral.c100
-            }
+            color={checked ? colors.primary.c90 : colors.neutral.c100}
             style={{ marginLeft: space[2] }}
           >
             {label}

--- a/packages/native/src/components/Form/Input/BaseInput/index.tsx
+++ b/packages/native/src/components/Form/Input/BaseInput/index.tsx
@@ -37,43 +37,43 @@ const InputContainer = styled.View<Partial<CommonProps> & { focus?: boolean }>`
   display: flex;
   flex-direction: row;
   width: 100%;
-  background: ${(p) => p.theme.colors.palette.neutral.c00};
+  background: ${(p) => p.theme.colors.neutral.c00};
   height: 48px;
-  border: ${(p) => `1px solid ${p.theme.colors.palette.neutral.c40}`};
+  border: ${(p) => `1px solid ${p.theme.colors.neutral.c40}`};
   border-radius: 24px;
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
 
   ${(p) =>
     p.disabled &&
     css`
-      color: ${p.theme.colors.palette.neutral.c60};
-      background: ${(p) => p.theme.colors.palette.neutral.c30};
+      color: ${p.theme.colors.neutral.c60};
+      background: ${(p) => p.theme.colors.neutral.c30};
     `};
 
   ${(p) =>
     p.focus &&
     !p.error &&
     css`
-      border: 1px solid ${p.theme.colors.palette.primary.c80};
+      border: 1px solid ${p.theme.colors.primary.c80};
     `};
 
   ${(p) =>
     p.error &&
     !p.disabled &&
     css`
-      border: 1px solid ${p.theme.colors.palette.error.c100};
+      border: 1px solid ${p.theme.colors.error.c100};
     `};
 
   ${(p) =>
     p.disabled &&
     css`
-      color: ${p.theme.colors.palette.neutral.c60};
-      background: ${(p) => p.theme.colors.palette.neutral.c30};
+      color: ${p.theme.colors.neutral.c60};
+      background: ${(p) => p.theme.colors.neutral.c30};
     `};
 `;
 
 const BaseInput = styled.TextInput.attrs((p) => ({
-  selectionColor: p.theme.colors.palette.primary.c80 as ColorValue,
+  selectionColor: p.theme.colors.primary.c80 as ColorValue,
 }))<Partial<CommonProps> & { focus?: boolean }>`
   height: 100%;
   width: 100%;
@@ -86,7 +86,7 @@ const BaseInput = styled.TextInput.attrs((p) => ({
 `;
 
 const InputErrorContainer = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.error.c100};
+  color: ${(p) => p.theme.colors.error.c100};
   margin-left: 12px;
 `;
 

--- a/packages/native/src/components/Form/Input/LegendInput/index.tsx
+++ b/packages/native/src/components/Form/Input/LegendInput/index.tsx
@@ -11,7 +11,7 @@ export default function LegendInput({
       {...inputProps}
       renderRight={
         <InputRenderRightContainer>
-          <Text color={"palette.neutral.c70"} variant="body">
+          <Text color={"neutral.c70"} variant="body">
             {legend}
           </Text>
         </InputRenderRightContainer>

--- a/packages/native/src/components/Form/Input/NumberInput/index.tsx
+++ b/packages/native/src/components/Form/Input/NumberInput/index.tsx
@@ -7,13 +7,9 @@ import Text from "../../../Text";
 
 const PercentButton = styled(TouchableOpacity)<{ active?: boolean }>`
   color: ${(p) =>
-    p.active
-      ? p.theme.colors.palette.neutral.c00
-      : p.theme.colors.palette.neutral.c70};
+    p.active ? p.theme.colors.neutral.c00 : p.theme.colors.neutral.c70};
   background-color: ${(p) =>
-    p.active
-      ? p.theme.colors.palette.neutral.c100
-      : p.theme.colors.palette.neutral.c00};
+    p.active ? p.theme.colors.neutral.c100 : p.theme.colors.neutral.c00};
   border-radius: 100px;
   border-width: 0;
   height: 31px;
@@ -74,7 +70,7 @@ export default function NumberInput({
               >
                 <Text
                   variant={"small"}
-                  color={active ? "palette.neutral.c00" : "palette.neutral.c70"}
+                  color={active ? "neutral.c00" : "neutral.c70"}
                 >
                   {percent * 100}%
                 </Text>

--- a/packages/native/src/components/Form/Input/QrCodeInput/index.tsx
+++ b/packages/native/src/components/Form/Input/QrCodeInput/index.tsx
@@ -6,7 +6,7 @@ import FlexBox from "../../../Layout/Flex";
 import QrCodeMedium from "@ledgerhq/icons-ui/native/QrCodeMedium";
 
 const QrCodeButton = styled(TouchableOpacity)`
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,7 +17,7 @@ const QrCodeButton = styled(TouchableOpacity)`
 `;
 
 const Icon = styled(QrCodeMedium).attrs((p) => ({
-  color: p.theme.colors.palette.neutral.c00,
+  color: p.theme.colors.neutral.c00,
 }))``;
 
 export default function QrCodeInput({

--- a/packages/native/src/components/Form/Input/SearchInput/index.tsx
+++ b/packages/native/src/components/Form/Input/SearchInput/index.tsx
@@ -4,7 +4,7 @@ import Input, { InputProps, InputRenderLeftContainer } from "../BaseInput";
 import SearchMedium from "@ledgerhq/icons-ui/native/SearchMedium";
 
 const Icon = styled(SearchMedium).attrs((p) => ({
-  color: p.theme.colors.palette.neutral.c70,
+  color: p.theme.colors.neutral.c70,
 }))``;
 
 export default function SearchInput(props: InputProps): JSX.Element {

--- a/packages/native/src/components/Form/SelectableList.tsx
+++ b/packages/native/src/components/Form/SelectableList.tsx
@@ -31,11 +31,9 @@ function Element<V>({
       <ElementContainer
         p={6}
         mt={first ? 0 : 4}
-        backgroundColor={
-          selected ? "palette.primary.c20" : "palette.neutral.c00"
-        }
+        backgroundColor={selected ? "primary.c20" : "neutral.c00"}
         border="1px solid"
-        borderColor={selected ? "palette.primary.c100" : "palette.neutral.c40"}
+        borderColor={selected ? "primary.c100" : "neutral.c40"}
         borderRadius={1}
       >
         <Text variant="large">{children || value}</Text>

--- a/packages/native/src/components/Form/Slider/components.tsx
+++ b/packages/native/src/components/Form/Slider/components.tsx
@@ -20,21 +20,21 @@ export const RailSelected = styled.View`
   margin-left: -5px;
   margin-right: -5px;
   height: 40px;
-  background-color: ${(p) => p.theme.colors.palette.primary.c40};
+  background-color: ${(p) => p.theme.colors.primary.c40};
   border-radius: 30px;
 `;
 
 export const Rail = styled.View`
   flex: 1;
   height: 40px;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c30};
+  background-color: ${(p) => p.theme.colors.neutral.c30};
   border-radius: 30px;
 `;
 
 const ThumbContainer = styled.View`
   height: 40px;
   width: 40px;
-  background-color: ${(p) => p.theme.colors.palette.primary.c90};
+  background-color: ${(p) => p.theme.colors.primary.c90};
   border-radius: 40px;
   display: flex;
   align-items: center;
@@ -45,7 +45,7 @@ export const Thumb = () => {
   const { colors } = useTheme();
   return (
     <ThumbContainer>
-      <ArrowsHMedium color={colors.palette.neutral.c00} size={24} />
+      <ArrowsHMedium color={colors.neutral.c00} size={24} />
     </ThumbContainer>
   );
 };
@@ -56,18 +56,14 @@ const LabelContainer = styled.View`
   justify-content: center;
   align-items: center;
   padding: 3.5px 6px;
-  background-color: ${(p) => p.theme.colors.palette.primary.c20};
+  background-color: ${(p) => p.theme.colors.primary.c20};
   border-radius: 4px;
 `;
 
 export const Label = ({ children }: { children: React.ReactNode }) => {
   return (
     <LabelContainer>
-      <Text
-        variant={"body"}
-        fontWeight={"semiBold"}
-        color={"palette.primary.c90"}
-      >
+      <Text variant={"body"} fontWeight={"semiBold"} color={"primary.c90"}>
         {children}
       </Text>
     </LabelContainer>

--- a/packages/native/src/components/Form/Slider/index.native.tsx
+++ b/packages/native/src/components/Form/Slider/index.native.tsx
@@ -55,18 +55,10 @@ const Slider = ({ value, min, max, step, onChange, disabled }: SliderProps) => {
         onValueChanged={onChange}
       />
       <MinMaxTextContainer>
-        <Text
-          variant={"small"}
-          fontWeight={"medium"}
-          color={"palette.neutral.c70"}
-        >
+        <Text variant={"small"} fontWeight={"medium"} color={"neutral.c70"}>
           {min}
         </Text>
-        <Text
-          variant={"small"}
-          fontWeight={"medium"}
-          color={"palette.neutral.c70"}
-        >
+        <Text variant={"small"} fontWeight={"medium"} color={"neutral.c70"}>
           {max}
         </Text>
       </MinMaxTextContainer>

--- a/packages/native/src/components/Form/Switch/index.tsx
+++ b/packages/native/src/components/Form/Switch/index.tsx
@@ -23,21 +23,19 @@ const Switch = ({
     <Flex flexDirection="row" alignItems="center">
       <NativeSwitch
         trackColor={{
-          false: colors.palette.neutral.c50,
-          true: colors.palette.primary.c80,
+          false: colors.neutral.c50,
+          true: colors.primary.c80,
         }}
-        thumbColor={colors.palette.neutral.c00}
+        thumbColor={colors.neutral.c00}
         onValueChange={onChange}
         value={checked}
         disabled={disabled}
-        ios_backgroundColor={colors.palette.neutral.c50}
+        ios_backgroundColor={colors.neutral.c50}
       />
       {label ? (
         <Text
           variant="body"
-          color={
-            checked ? colors.palette.primary.c90 : colors.palette.neutral.c100
-          }
+          color={checked ? colors.primary.c90 : colors.neutral.c100}
           style={{ marginLeft: space[3] }}
         >
           {label}

--- a/packages/native/src/components/Icon/IconBox/index.tsx
+++ b/packages/native/src/components/Icon/IconBox/index.tsx
@@ -22,7 +22,7 @@ const IconContainer = styled.View`
   align-items: center;
   justify-content: center;
   border-width: 1px;
-  border-color: ${(p) => p.theme.colors.palette.neutral.c40};
+  border-color: ${(p) => p.theme.colors.neutral.c40};
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
 `;
 
@@ -35,7 +35,7 @@ export default function IconBox({
   const { colors } = useTheme();
   return (
     <IconContainer size={boxSize}>
-      <Icon size={iconSize} color={color || colors.palette.neutral.c100} />
+      <Icon size={iconSize} color={color || colors.neutral.c100} />
     </IconContainer>
   );
 }

--- a/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -28,7 +28,7 @@ export type BaseModalProps = {
 } & Partial<ModalProps>;
 
 const Container = styled.View`
-  background-color: ${(p) => p.theme.colors.palette.background.main};
+  background-color: ${(p) => p.theme.colors.background.main};
   width: 100%;
   padding: 16px;
   min-height: 350px;
@@ -57,7 +57,7 @@ const StyledTitle = styled(Text).attrs({ variant: "h3" })`
 
 const StyledDescription = styled(Text).attrs({
   variant: "body",
-  color: "palette.neutral.c80",
+  color: "neutral.c80",
 })`
   text-transform: capitalize;
   margin-top: ${(p) => p.theme.space[2]}px;
@@ -65,7 +65,7 @@ const StyledDescription = styled(Text).attrs({
 
 const StyledSubtitle = styled(Text).attrs({
   variant: "subtitle",
-  color: "palette.neutral.c80",
+  color: "neutral.c80",
 })`
   text-transform: uppercase;
   margin-bottom: ${(p) => p.theme.space[2]}px;
@@ -123,7 +123,7 @@ export default function BaseModal({
               {typeof Icon === "function"
                 ? Icon({
                     size: 48,
-                    color: iconColor || colors.palette.neutral.c100,
+                    color: iconColor || colors.neutral.c100,
                   })
                 : Icon}
             </FlexBox>

--- a/packages/native/src/components/Layout/ScrollContainerHeader/Header.tsx
+++ b/packages/native/src/components/Layout/ScrollContainerHeader/Header.tsx
@@ -21,7 +21,7 @@ export type HeaderProps = {
 const Container = styled(Flex).attrs({
   paddingHorizontal: 16,
 })`
-  background-color: ${(p) => p.theme.colors.palette.background.main};
+  background-color: ${(p) => p.theme.colors.background.main};
   width: 100%;
 `;
 

--- a/packages/native/src/components/Loader/index.tsx
+++ b/packages/native/src/components/Loader/index.tsx
@@ -27,8 +27,8 @@ const ProgressLoader = ({
   Icon,
 }: Props): React.ReactElement => {
   const { colors } = useTheme();
-  const backgroundColor = colors.palette.primary.c20;
-  const progressColor = colors.palette.primary.c90;
+  const backgroundColor = colors.primary.c20;
+  const progressColor = colors.primary.c90;
 
   const strokeDashoffset = circumference - progress * circumference;
   return (

--- a/packages/native/src/components/Navigation/SlideIndicator/index.tsx
+++ b/packages/native/src/components/Navigation/SlideIndicator/index.tsx
@@ -25,11 +25,11 @@ const Bullet = styled.TouchableOpacity`
   height: 6px;
   border-radius: 6px;
   margin: 0 6px;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c40};
+  background-color: ${(p) => p.theme.colors.neutral.c40};
 `;
 
 const ActiveBullet = styled(Bullet)`
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
   position: absolute;
   top: 0;
   left: 0;

--- a/packages/native/src/components/Navigation/Stepper/index.tsx
+++ b/packages/native/src/components/Navigation/Stepper/index.tsx
@@ -21,13 +21,13 @@ type AnimatedSeparatorProps = {
 const Separator = styled.View<SpaceProps>`
   flex: 1;
   height: 1px;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c40};
+  background-color: ${(p) => p.theme.colors.neutral.c40};
   ${space}
 `;
 
 const SeparatorFilling = Animated.createAnimatedComponent(styled.View`
   height: 100%;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
 `);
 
 const AnimatedSeparator = ({
@@ -84,13 +84,13 @@ const StepIcon = {
     width: ${(p) => p.theme.space[2]}px;
     height: ${(p) => p.theme.space[2]}px;
     border-radius: ${(p) => p.theme.radii[2]}px;
-    background-color: ${(p) => p.theme.colors.palette.primary.c90};
+    background-color: ${(p) => p.theme.colors.primary.c90};
   `,
   Pending: styled.View`
     width: ${(p) => p.theme.space[1]}px;
     height: ${(p) => p.theme.space[1]}px;
     border-radius: ${(p) => p.theme.space[1]}px;
-    background-color: ${(p) => p.theme.colors.palette.neutral.c70};
+    background-color: ${(p) => p.theme.colors.neutral.c70};
   `,
   Completed: ({ color }: { color: string }): JSX.Element => (
     <CheckAlone size={16} color={color} />
@@ -108,15 +108,15 @@ const StepView = styled.View`
 `;
 
 const ActiveText = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
 `;
 
 const PendingText = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.neutral.c70};
+  color: ${(p) => p.theme.colors.neutral.c70};
 `;
 
 const ErroredText = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.error.c100};
+  color: ${(p) => p.theme.colors.error.c100};
 `;
 
 type StepState = "CURRENT" | "PENDING" | "COMPLETED" | "ERRORED";
@@ -151,20 +151,20 @@ function Step({
     switch (state) {
       case "COMPLETED":
         return (
-          <StepIcon.Background backgroundColor="palette.primary.c20">
-            <StepIcon.Completed color={colors.palette.primary.c90} />
+          <StepIcon.Background backgroundColor="primary.c20">
+            <StepIcon.Completed color={colors.primary.c90} />
           </StepIcon.Background>
         );
       case "CURRENT":
         return (
-          <StepIcon.Background backgroundColor="palette.primary.c20">
+          <StepIcon.Background backgroundColor="primary.c20">
             <StepIcon.Current />
           </StepIcon.Background>
         );
       case "ERRORED":
         return (
-          <StepIcon.Background backgroundColor="palette.warning.c30">
-            <StepIcon.Errored color={colors.palette.error.c100} />
+          <StepIcon.Background backgroundColor="warning.c30">
+            <StepIcon.Errored color={colors.error.c100} />
           </StepIcon.Background>
         );
       case "PENDING":

--- a/packages/native/src/components/Navigation/ToggleGroup/index.tsx
+++ b/packages/native/src/components/Navigation/ToggleGroup/index.tsx
@@ -16,7 +16,7 @@ export const ToggleGroupContainer = styled(FlexBox).attrs({
   alignItems: "stretch",
 })`
   width: 100%;
-  border: ${(p) => `1px solid ${p.theme.colors.palette.neutral.c40}`};
+  border: ${(p) => `1px solid ${p.theme.colors.neutral.c40}`};
   border-radius: 35px;
   padding: 4px;
 `;

--- a/packages/native/src/components/Text/index.tsx
+++ b/packages/native/src/components/Text/index.tsx
@@ -47,7 +47,7 @@ export interface BaseTextProps
 
 const Base = styled.Text.attrs((p: BaseTextProps) => ({
   fontSize: p.fontSize ? p.fontSize : p.variant ?? "paragraph",
-  color: p.color || "palette.neutral.c100",
+  color: p.color || "neutral.c100",
 }))<BaseTextProps>`
   ${(p) => getTextStyle(p)}
   ${lineHeight};
@@ -68,7 +68,7 @@ const T = styled.View`
 
 const BracketText = ({
   children,
-  color = "palette.neutral.c100",
+  color = "neutral.c100",
   lineHeight,
   ...props
 }: BaseTextProps) => {

--- a/packages/native/src/components/chart/index.tsx
+++ b/packages/native/src/components/chart/index.tsx
@@ -15,7 +15,7 @@ import Flex from "../Layout/Flex";
 import type { Item } from "./types";
 
 const Container = styled(Flex)`
-  background-color: ${(p) => p.theme.colors.palette.background.main};
+  background-color: ${(p) => p.theme.colors.background.main};
 `;
 
 const sortByDate = (a: Item, b: Item): -1 | 0 | 1 => {
@@ -60,7 +60,7 @@ const Chart = ({
           crossAxis
           style={{
             grid: {
-              stroke: theme.colors.palette.neutral.c40,
+              stroke: theme.colors.neutral.c40,
               strokeDasharray: "4 4",
             },
             axisLabel: { display: "none" },
@@ -76,11 +76,11 @@ const Chart = ({
           tickFormat={(timestamp) => moment(timestamp).format(tickFormat)}
           style={{
             axis: {
-              stroke: theme.colors.palette.neutral.c40,
+              stroke: theme.colors.neutral.c40,
               strokeDasharray: "4 4",
             },
             tickLabels: {
-              fill: theme.colors.palette.neutral.c80,
+              fill: theme.colors.neutral.c80,
               fontSize: 12,
               lineHeight: 14.52,
             },
@@ -94,7 +94,7 @@ const Chart = ({
             <Stop stopColor={hex(color)} stopOpacity="0.11" />
             <Stop
               offset="1"
-              stopColor={hex(theme.colors.palette.neutral.c00)}
+              stopColor={hex(theme.colors.neutral.c00)}
               stopOpacity="0"
             />
           </LinearGradient>
@@ -124,7 +124,7 @@ const Chart = ({
             data: {
               stroke: color,
               strokeWidth: 3,
-              fill: theme.colors.palette.background.main,
+              fill: theme.colors.background.main,
             },
           }}
           size={5}

--- a/packages/native/src/components/cta/Button/getButtonStyle.ts
+++ b/packages/native/src/components/cta/Button/getButtonStyle.ts
@@ -10,29 +10,29 @@ export function getButtonColors(colors: Theme["colors"]): {
 } {
   return {
     default: {
-      primaryColor: colors.palette.neutral.c100,
+      primaryColor: colors.neutral.c100,
       secondaryColor: "rgba(0,0,0,0)",
     },
     disabled: {
-      primaryColor: colors.palette.neutral.c50,
-      secondaryColor: colors.palette.neutral.c30,
+      primaryColor: colors.neutral.c50,
+      secondaryColor: colors.neutral.c30,
     },
     main: {
-      primaryColor: colors.palette.neutral.c00,
-      secondaryColor: colors.palette.neutral.c100,
+      primaryColor: colors.neutral.c00,
+      secondaryColor: colors.neutral.c100,
     },
     shade: {
-      primaryColor: colors.palette.neutral.c00,
-      secondaryColor: colors.palette.neutral.c100,
-      tertiaryColor: colors.palette.neutral.c40,
+      primaryColor: colors.neutral.c00,
+      secondaryColor: colors.neutral.c100,
+      tertiaryColor: colors.neutral.c40,
     },
     error: {
-      primaryColor: colors.palette.neutral.c00,
-      secondaryColor: colors.palette.error.c100,
+      primaryColor: colors.neutral.c00,
+      secondaryColor: colors.error.c100,
     },
     color: {
-      primaryColor: colors.palette.neutral.c00,
-      secondaryColor: colors.palette.primary.c80,
+      primaryColor: colors.neutral.c00,
+      secondaryColor: colors.primary.c80,
     },
   };
 }

--- a/packages/native/src/components/cta/Button/index.tsx
+++ b/packages/native/src/components/cta/Button/index.tsx
@@ -179,7 +179,7 @@ export const PromisableButton = (props: ButtonProps): React.ReactElement => {
       <ButtonContainer {...props} type={type} size={size} hide={spinnerOn} />
       <SpinnerContainer>
         <ActivityIndicator
-          color={theme.colors.palette.neutral.c50}
+          color={theme.colors.neutral.c50}
           animating={spinnerOn}
         />
       </SpinnerContainer>

--- a/packages/native/src/components/cta/Link/getLinkStyle.ts
+++ b/packages/native/src/components/cta/Link/getLinkStyle.ts
@@ -10,16 +10,16 @@ export function getLinkColors(colors: Theme["colors"]): {
 } {
   return {
     default: {
-      disabled: colors.palette.neutral.c50,
-      main: colors.palette.neutral.c100,
-      color: colors.palette.primary.c80,
-      shade: colors.palette.neutral.c70,
+      disabled: colors.neutral.c50,
+      main: colors.neutral.c100,
+      color: colors.primary.c80,
+      shade: colors.neutral.c70,
     },
     reversed: {
-      disabled: colors.palette.neutral.c80,
-      main: colors.palette.neutral.c00,
-      color: colors.palette.primary.c60,
-      shade: colors.palette.neutral.c50,
+      disabled: colors.neutral.c80,
+      main: colors.neutral.c00,
+      color: colors.primary.c60,
+      shade: colors.neutral.c50,
     },
   };
 }

--- a/packages/native/src/components/drawer/Notification/index.tsx
+++ b/packages/native/src/components/drawer/Notification/index.tsx
@@ -27,9 +27,7 @@ const NotificationContainer = styled.View<Partial<Props>>`
   align-items: center;
   padding: 16px;
   background-color: ${(p) =>
-    p.variant === "primary"
-      ? p.theme.colors.palette.primary.c90
-      : "transparent"};
+    p.variant === "primary" ? p.theme.colors.primary.c90 : "transparent"};
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
 `;
 
@@ -45,9 +43,7 @@ export default function Notification({
 }: Props): React.ReactElement {
   const { colors } = useTheme();
   const textColor =
-    variant === "primary"
-      ? colors.palette.neutral.c00
-      : colors.palette.neutral.c100;
+    variant === "primary" ? colors.neutral.c00 : colors.neutral.c100;
 
   return (
     <NotificationContainer variant={variant}>
@@ -69,9 +65,7 @@ export default function Notification({
             fontWeight={"medium"}
             color={
               color ||
-              (variant === "primary"
-                ? colors.palette.neutral.c00
-                : colors.palette.neutral.c80)
+              (variant === "primary" ? colors.neutral.c00 : colors.neutral.c80)
             }
             mt={"2px"}
             mb={"2px"}

--- a/packages/native/src/components/message/Alert/index.tsx
+++ b/packages/native/src/components/message/Alert/index.tsx
@@ -23,16 +23,16 @@ const icons = {
 
 const alertColors = {
   info: {
-    backgroundColor: "palette.primary.c20",
-    color: "palette.primary.c90",
+    backgroundColor: "primary.c20",
+    color: "primary.c90",
   },
   warning: {
-    backgroundColor: "palette.warning.c30",
-    color: "palette.warning.c100",
+    backgroundColor: "warning.c30",
+    color: "warning.c100",
   },
   error: {
-    backgroundColor: "palette.error.c30",
-    color: "palette.error.c100",
+    backgroundColor: "error.c30",
+    color: "error.c100",
   },
 };
 

--- a/packages/native/src/components/tags/Badge/index.tsx
+++ b/packages/native/src/components/tags/Badge/index.tsx
@@ -22,22 +22,22 @@ const badgesStyle: {
 } = {
   main: {
     default: {
-      color: "palette.neutral.c80",
+      color: "neutral.c80",
       borderWidth: 1,
-      borderColor: "palette.neutral.c40",
+      borderColor: "neutral.c40",
     },
     active: {
-      color: "palette.neutral.c00",
-      backgroundColor: "palette.neutral.c100",
+      color: "neutral.c00",
+      backgroundColor: "neutral.c100",
     },
   },
   primary: {
     default: {
-      color: "palette.primary.c90",
+      color: "primary.c90",
     },
     active: {
-      color: "palette.primary.c90",
-      backgroundColor: "palette.primary.c20",
+      color: "primary.c90",
+      backgroundColor: "primary.c20",
     },
   },
 };

--- a/packages/native/src/icons/Close.tsx
+++ b/packages/native/src/icons/Close.tsx
@@ -12,7 +12,7 @@ export default function Close({ size = 16, color }: Props): React.ReactElement {
   return (
     <Svg viewBox="0 0 16 16" width={size} height={size}>
       <Path
-        fill={color || colors.palette.neutral.c100}
+        fill={color || colors.neutral.c100}
         d="M9.65 8.413l4.066-4.065a.375.375 0 0 0 0-.532l-.706-.706a.375.375 0 0 0-.531 0L8.413 7.176 4.348 3.11a.375.375 0 0 0-.532 0l-.706.706a.375.375 0 0 0 0 .532l4.066 4.065L3.11 12.48a.375.375 0 0 0 0 .531l.706.706a.375.375 0 0 0 .532 0l4.065-4.065 4.066 4.065a.375.375 0 0 0 .531 0l.706-.706a.375.375 0 0 0 0-.531L9.651 8.413z"
       />
     </Svg>

--- a/packages/native/src/styles/StyleProvider.tsx
+++ b/packages/native/src/styles/StyleProvider.tsx
@@ -23,6 +23,7 @@ export const StyleProvider = ({
       ...defaultTheme,
       colors: {
         ...defaultTheme.colors,
+        ...palettes[selectedPalette],
         palette: palettes[selectedPalette],
       },
       theme: selectedPalette,

--- a/packages/native/src/styles/theme.ts
+++ b/packages/native/src/styles/theme.ts
@@ -51,7 +51,12 @@ export type Theme = {
   radii: number[];
   fontSizes: number[];
   space: number[];
-  colors: { palette: ColorPalette };
+  colors: ColorPalette & {
+    /**
+     * @deprecated Do not use the .palette prefix anymore!
+     */
+    palette: ColorPalette;
+  };
   zIndexes: number[];
 };
 
@@ -65,6 +70,7 @@ const theme: Theme = {
   fontSizes,
   space,
   colors: {
+    ...palettes.light,
     palette: palettes.light,
   },
   zIndexes,

--- a/packages/native/storybook/stories/CenterView/index.tsx
+++ b/packages/native/storybook/stories/CenterView/index.tsx
@@ -8,7 +8,7 @@ export const Main = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
-  background-color: ${(p) => p.theme.colors.palette.background.main};
+  background-color: ${(p) => p.theme.colors.background.main};
   overflow: hidden;
 `;
 
@@ -17,7 +17,7 @@ const ThemeButton = styled.TouchableOpacity`
   height: ${(p) => p.theme.space[10]}px;
   border-top-left-radius: ${(p) => p.theme.space[10]};
   border-bottom-left-radius: ${(p) => p.theme.space[10]};
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
   justify-content: center;
   align-items: center;
   position: absolute;
@@ -27,7 +27,7 @@ const ThemeButton = styled.TouchableOpacity`
 `;
 
 const Icon = styled.Text`
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
   font-size: 15px;
 `;
 

--- a/packages/native/storybook/stories/Chart/Chart.stories.tsx
+++ b/packages/native/storybook/stories/Chart/Chart.stories.tsx
@@ -37,7 +37,7 @@ const ChartDefault = (): JSX.Element => {
   return (
     <Flex alignItems="flex-start" flexDirection="column">
       <Chart
-        color={color("color", theme.colors.palette.primary.c100)}
+        color={color("color", theme.colors.primary.c100)}
         tickFormat={text("tickFormat", "MMM")}
         data={generateData()}
       />

--- a/packages/native/storybook/stories/Layout/ScrollContainerHeader.stories.tsx
+++ b/packages/native/storybook/stories/Layout/ScrollContainerHeader.stories.tsx
@@ -53,7 +53,7 @@ const ScrollContainerHeaderStory = () => {
           <Flex
             height="100px"
             key={i}
-            bg={i % 2 ? "palette.primary.c20" : "palette.neutral.c20"}
+            bg={i % 2 ? "primary.c20" : "neutral.c20"}
           />
         ))}
     </ScrollContainerHeader>

--- a/packages/native/storybook/stories/Layout/Table.stories.tsx
+++ b/packages/native/storybook/stories/Layout/Table.stories.tsx
@@ -37,7 +37,7 @@ const TopLeft = () => {
 const BottomLeft = () => {
   const { colors } = useTheme();
   return (
-    <Text variant="body" color={colors.palette.neutral.c70}>
+    <Text variant="body" color={colors.neutral.c70}>
       {text("bottomLeftText", "Native Segwit", "content")}
     </Text>
   );
@@ -46,11 +46,7 @@ const BottomLeft = () => {
 const TopRight = () => {
   const { colors } = useTheme();
   return (
-    <Text
-      color={colors.palette.neutral.c100}
-      variant="body"
-      fontWeight="semiBold"
-    >
+    <Text color={colors.neutral.c100} variant="body" fontWeight="semiBold">
       {text("topRightText", "1.23456 BTC", "content")}
     </Text>
   );
@@ -59,11 +55,7 @@ const TopRight = () => {
 const BottomRight = () => {
   const { colors } = useTheme();
   return (
-    <Text
-      variant="paragraph"
-      fontWeight="medium"
-      color={colors.palette.neutral.c70}
-    >
+    <Text variant="paragraph" fontWeight="medium" color={colors.neutral.c70}>
       {text("bottomRightText", "$74,590.81", "content")}
     </Text>
   );

--- a/packages/native/storybook/stories/Particles/Spacing.stories.tsx
+++ b/packages/native/storybook/stories/Particles/Spacing.stories.tsx
@@ -17,16 +17,16 @@ const SpacingStory = () => {
     >
       {space.map((value, index) => (
         <Flex mb={4} width="90%" key={value}>
-          <Text variant="small" color={theme.colors.palette.neutral.c100}>
+          <Text variant="small" color={theme.colors.neutral.c100}>
             {value}
-            <Text ml={4} variant="small" color="palette.neutral.c70">
+            <Text ml={4} variant="small" color="neutral.c70">
               space[{index + 1}]
             </Text>
           </Text>
           <View
             style={{
               height: value,
-              backgroundColor: theme.colors.palette.primary.c20,
+              backgroundColor: theme.colors.primary.c20,
             }}
           />
         </Flex>

--- a/packages/native/storybook/stories/Text/Text.stories.tsx
+++ b/packages/native/storybook/stories/Text/Text.stories.tsx
@@ -30,11 +30,7 @@ storiesOf((story) =>
         ["medium", "semiBold", "bold"],
         "medium"
       )}
-      color={select(
-        "color",
-        ["palette.primary.c100", "palette.neutral.c100"],
-        "palette.neutral.c100"
-      )}
+      color={select("color", ["primary.c100", "neutral.c100"], "neutral.c100")}
       bracket={boolean("bracket", false)}
     >
       {text("label", "Ledger")}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -59,7 +59,7 @@ import { Text, Flex, Logos } from "@ledgerhq/react-ui";
 function Hello() {
   return (
     <Flex flexDirection="column" alignItems="center" rowGap={12} p={12}>
-      <Text color="palette.neutral.c100">
+      <Text color="neutral.c100">
         <Logos.LedgerLiveRegular />
       </Text>
       <Text variant="h1">Hello, world!</Text>
@@ -172,7 +172,7 @@ function Root() {
   return (
     <StyleProvider fontsPath="assets" selectedPalette={palette}>
       <Flex flexDirection="column" alignItems="center" rowGap={12} p={12}>
-        <Text color="palette.neutral.c100">
+        <Text color="neutral.c100">
           <Logos.LedgerLiveRegular />
         </Text>
         <Text variant="h1">Hello, world!</Text>

--- a/packages/react/src/components/Chart/Chart.stories.tsx
+++ b/packages/react/src/components/Chart/Chart.stories.tsx
@@ -112,12 +112,7 @@ export const Small = (args: ChartPreviewProps): JSX.Element => {
     <Flex alignItems="flex-start" flexDirection="column" rowGap="1rem">
       <Flex flexWrap="wrap" rowGap="1.5rem" columnGap="2rem">
         <CardChart>
-          <Chart
-            id="static"
-            variant="small"
-            color={theme.colors.palette.primary.c100}
-            data={data}
-          />
+          <Chart id="static" variant="small" color={theme.colors.primary.c100} data={data} />
         </CardChart>
         <CardChart>
           <Chart id="dynamic" variant="small" color={args.color} data={data} />

--- a/packages/react/src/components/Chart/index.tsx
+++ b/packages/react/src/components/Chart/index.tsx
@@ -104,8 +104,8 @@ export default ({
 }: Props): JSX.Element => {
   const theme = useTheme();
   const config = useMemo(
-    () => getConfig(variant, { gridColor: theme.colors.palette.neutral.c40, timeOptions }),
-    [variant, theme.colors.palette.neutral.c40, timeOptions],
+    () => getConfig(variant, { gridColor: theme.colors.neutral.c40, timeOptions }),
+    [variant, theme.colors.neutral.c40, timeOptions],
   );
 
   // inject default font configuration at mount

--- a/packages/react/src/components/Table/Columns.tsx
+++ b/packages/react/src/components/Table/Columns.tsx
@@ -81,7 +81,7 @@ export function TextColumn<T>({
             variant={"body"}
             textOverflow="ellipsis"
             overflow="hidden"
-            color="palette.neutral.c100"
+            color="neutral.c100"
             {...((titleProps && titleProps(elt)) || {})}
           >
             {title(elt)}
@@ -93,7 +93,7 @@ export function TextColumn<T>({
             variant={"paragraph"}
             textOverflow="ellipsis"
             overflow="hidden"
-            color="palette.neutral.c80"
+            color="neutral.c80"
             {...((subtitleProps && subtitleProps(elt)) || {})}
           >
             {subtitle(elt)}

--- a/packages/react/src/components/Table/Table.stories.tsx
+++ b/packages/react/src/components/Table/Table.stories.tsx
@@ -36,7 +36,7 @@ export function Default(args: Props<BalanceElement>): JSX.Element {
         gridRowGap={8}
         gridColumnGap={6}
         borderRadius={8}
-        backgroundColor="palette.neutral.c20"
+        backgroundColor="neutral.c20"
         p={8}
       />
     </>
@@ -69,7 +69,7 @@ function SubAccounts({
                     width: "1px",
                     height: "2em",
                     marginRight: `${theme.space[6]}px`,
-                    borderLeft: `1px solid ${theme.colors.palette.neutral.c40}`,
+                    borderLeft: `1px solid ${theme.colors.neutral.c40}`,
                   }}
                 />
                 {children}
@@ -104,7 +104,7 @@ export function Nested(args: Props<Account>): JSX.Element {
         gridColumnGap={6}
         p={8}
         borderRadius={8}
-        backgroundColor="palette.neutral.c20"
+        backgroundColor="neutral.c20"
         extraRender={(account) =>
           account.subAccounts &&
           account.subAccounts.length > 0 && (

--- a/packages/react/src/components/Table/stories.helper.tsx
+++ b/packages/react/src/components/Table/stories.helper.tsx
@@ -10,7 +10,7 @@ function Header({ children }: { children: React.ReactNode }) {
     <Text
       fontWeight="semiBold"
       variant={"paragraph"}
-      style={{ borderBottom: `1px solid ${theme.colors.palette.neutral.c40}` }}
+      style={{ borderBottom: `1px solid ${theme.colors.neutral.c40}` }}
       mx={-4}
       px={4}
       pb={8}
@@ -82,14 +82,14 @@ export const balance: { data: BalanceElement[]; columns: Column<BalanceElement>[
       header: () => <Header>Evolution</Header>,
       subtitle: (elt) => (elt.evolution > 0 ? "+" : "") + elt.evolution,
       subtitleProps: (elt) => ({
-        color: elt.evolution < 0 ? "palette.error.c100" : "palette.success.c100",
+        color: elt.evolution < 0 ? "error.c100" : "success.c100",
       }),
     }),
     IconColumn({
       header: () => <Header>&nbsp;</Header>,
       props: (elt) => ({
         name: "StarSolid",
-        color: elt.starred ? "palette.neutral.c100" : "palette.neutral.c70",
+        color: elt.starred ? "neutral.c100" : "neutral.c70",
       }),
     }),
   ],
@@ -180,7 +180,7 @@ export const accounts: { data: Account[]; columns: Column<Account>[] } = {
     IconColumn({
       props: (elt) => ({
         name: elt.synchronized ? "CircledCheck" : "Clock",
-        color: elt.synchronized ? "palette.success.c100" : "palette.neutral.c80",
+        color: elt.synchronized ? "success.c100" : "neutral.c80",
       }),
     }),
     TextColumn({
@@ -195,13 +195,13 @@ export const accounts: { data: Account[]; columns: Column<Account>[] } = {
       layout: "1fr",
       subtitle: (elt) => (elt.evolution > 0 ? "+" : "") + elt.evolution,
       subtitleProps: (elt) => ({
-        color: elt.evolution < 0 ? "palette.error.c100" : "palette.success.c100",
+        color: elt.evolution < 0 ? "error.c100" : "success.c100",
       }),
     }),
     IconColumn({
       props: (elt) => ({
         name: "StarSolid",
-        color: elt.starred ? "palette.neutral.c100" : "palette.neutral.c70",
+        color: elt.starred ? "neutral.c100" : "neutral.c70",
       }),
     }),
   ],

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -40,7 +40,7 @@ export const Overview = ((): JSX.Element => (
         {types.map((type) => (
           <Flex flexDirection="row" alignItems="center" mb={5}>
             <div style={{ width: "150px" }}>
-              <Text variant="small" color="palette.neutral.c70">
+              <Text variant="small" color="neutral.c70">
                 type="{type}"
               </Text>
             </div>

--- a/packages/react/src/components/Tag/index.tsx
+++ b/packages/react/src/components/Tag/index.tsx
@@ -33,19 +33,19 @@ export type TagProps = BaseStyledProps &
 function getColor({ type, active, disabled }: TagProps) {
   switch (type) {
     case "plain":
-      if (disabled) return active ? "palette.neutral.c00" : "palette.neutral.c70";
-      return active ? "palette.neutral.c00" : "palette.primary.c90";
+      if (disabled) return active ? "neutral.c00" : "neutral.c70";
+      return active ? "neutral.c00" : "primary.c90";
     default:
-      return disabled ? "palette.neutral.c70" : "palette.primary.c90";
+      return disabled ? "neutral.c70" : "primary.c90";
   }
 }
 
 function getBgColor({ type, active, disabled }: TagProps) {
   switch (type) {
     case "plain":
-      return active ? (disabled ? "palette.neutral.c70" : "palette.primary.c90") : undefined;
+      return active ? (disabled ? "neutral.c70" : "primary.c90") : undefined;
     case "opacity":
-      return active ? (disabled ? "palette.neutral.c30" : "palette.primary.c20") : undefined;
+      return active ? (disabled ? "neutral.c30" : "primary.c20") : undefined;
     default:
       return;
   }
@@ -55,9 +55,9 @@ function getBorderColor({ type, active, disabled }: TagProps) {
   if (!active) return;
   switch (type) {
     case "outlined":
-      return disabled ? "palette.neutral.c70" : "palette.primary.c90";
+      return disabled ? "neutral.c70" : "primary.c90";
     case "outlinedOpacity":
-      return disabled ? "palette.neutral.c40" : "palette.primary.c40";
+      return disabled ? "neutral.c40" : "primary.c40";
   }
 }
 

--- a/packages/react/src/components/asorted/Divider/index.tsx
+++ b/packages/react/src/components/asorted/Divider/index.tsx
@@ -3,11 +3,11 @@ import styled from "styled-components";
 
 const Divider = styled.div`
   display: block;
-  background: ${(p) => p.theme.colors.palette.neutral.c90};
+  background: ${(p) => p.theme.colors.neutral.c90};
   height: 1px;
 
   &[data-variant="light"] {
-    background: ${(p) => p.theme.colors.palette.neutral.c40};
+    background: ${(p) => p.theme.colors.neutral.c40};
   }
 `;
 

--- a/packages/react/src/components/asorted/Icon/Icon.tsx
+++ b/packages/react/src/components/asorted/Icon/Icon.tsx
@@ -36,7 +36,7 @@ const Icon = ({
 
 export const IconBox = styled.div`
   padding: ${(p) => p.theme.space[6]}px;
-  border: 1px solid ${(p) => p.theme.colors.palette.neutral.c40};
+  border: 1px solid ${(p) => p.theme.colors.neutral.c40};
   border-radius: ${(p) => p.theme.radii[2]}px;
   display: inline-flex;
 `;

--- a/packages/react/src/components/asorted/Icon/Icons.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/Icons.stories.tsx
@@ -25,13 +25,13 @@ const IconContainer = styled(Flex).attrs<{ active?: boolean }>({
   alignItems: "center",
   p: 4,
 })<{ active?: boolean }>`
-  ${(p) => (p.active ? `background-color: ${p.theme.colors.palette.neutral.c20};` : ``)}
+  ${(p) => (p.active ? `background-color: ${p.theme.colors.neutral.c20};` : ``)}
   border-radius: 4px;
   height: 100px;
 `;
 
 const Bold = styled.b`
-  color: ${(p) => p.theme.colors.palette.primary.c80};
+  color: ${(p) => p.theme.colors.primary.c80};
 `;
 
 const Story = {
@@ -75,7 +75,7 @@ export default Story;
 
 const ListTemplate = (args: IconProps) => {
   const theme = useTheme();
-  const color = args.color || theme.colors.palette.neutral.c100;
+  const color = args.color || theme.colors.neutral.c100;
   const [search, setSearch] = useState("");
   const s = search.toLowerCase();
   const regexp = new RegExp(s, "i");
@@ -128,14 +128,14 @@ const ListTemplate = (args: IconProps) => {
 };
 const IconTemplate = (args: IconProps) => {
   const theme = useTheme();
-  const color = args.color || theme.colors.palette.neutral.c100;
+  const color = args.color || theme.colors.neutral.c100;
 
   return <Icon {...args} color={color} />;
 };
 
 const BoxedIconTemplate = (args: IconProps) => {
   const theme = useTheme();
-  const color = args.color || theme.colors.palette.neutral.c100;
+  const color = args.color || theme.colors.neutral.c100;
 
   return (
     <IconBox>

--- a/packages/react/src/components/asorted/Text/Text.stories.tsx
+++ b/packages/react/src/components/asorted/Text/Text.stories.tsx
@@ -69,11 +69,11 @@ export const Overview = (() => {
         return (
           <Flex flexDirection="row" style={{ height: "100px" }}>
             <div style={{ minWidth: 250 }}>
-              <Text variant="small" color="palette.neutral.c90">
+              <Text variant="small" color="neutral.c90">
                 variant="{variant}"
               </Text>
               <br />
-              <Text variant="tiny" color="palette.neutral.c70">
+              <Text variant="tiny" color="neutral.c70">
                 fontWeights: {JSON.stringify(fontWeightsToShow)}
               </Text>
             </div>

--- a/packages/react/src/components/asorted/Text/index.tsx
+++ b/packages/react/src/components/asorted/Text/index.tsx
@@ -48,7 +48,7 @@ export interface TextProps extends BaseStyledProps {
 const Text = baseStyled.span.attrs<TextProps, TextProps>(
   ({ variant = "body", fontSize, color }) => ({
     fontSize: fontSize ? fontSize : variant,
-    color: color || "palette.neutral.c100",
+    color: color || "neutral.c100",
   }),
 )`
   font-weight: 500;

--- a/packages/react/src/components/cards/Carousel/Slide.tsx
+++ b/packages/react/src/components/cards/Carousel/Slide.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled(Flex)<{ image?: string }>`
   padding: ${(p) => p.theme.space[8]}px ${(p) => p.theme.space[10]}px;
   padding-right: 280px; // Nb gives air to not overlap the illustration
   z-index: ${(p) => p.theme.zIndexes[8]};
-  background: url(${(p) => p.image}) no-repeat ${(p) => p.theme.colors.palette.neutral.c100};
+  background: url(${(p) => p.image}) no-repeat ${(p) => p.theme.colors.neutral.c100};
   background-size: contain;
   background-position: right 60px bottom;
 `;
@@ -26,10 +26,10 @@ export type Props = {
 const Slide = ({ title, description, image, onClick }: Props): React.ReactElement => {
   return (
     <Wrapper key={"key"} image={image} onClick={onClick}>
-      <Text variant={"tiny"} color="palette.neutral.c00" fontWeight="regular">
+      <Text variant={"tiny"} color="neutral.c00" fontWeight="regular">
         {title}
       </Text>
-      <Text variant={"h5"} color="palette.neutral.c00" textTransform="uppercase">
+      <Text variant={"h5"} color="neutral.c00" textTransform="uppercase">
         {description}
       </Text>
     </Wrapper>

--- a/packages/react/src/components/cards/Carousel/index.tsx
+++ b/packages/react/src/components/cards/Carousel/index.tsx
@@ -20,7 +20,7 @@ const CarouselWrapper = styled.div`
   cursor: pointer;
   position: relative;
   flex: 1;
-  background: ${(p) => p.theme.colors.palette.neutral.c100};
+  background: ${(p) => p.theme.colors.neutral.c100};
 `;
 
 const Controllers = styled(Flex)`
@@ -29,7 +29,7 @@ const Controllers = styled(Flex)`
   right: ${(p) => p.theme.space[5]}px;
   bottom: ${(p) => p.theme.space[4]}px;
   column-gap: ${(p) => p.theme.space[4]}px;
-  color: ${(p) => p.theme.colors.palette.neutral.c00};
+  color: ${(p) => p.theme.colors.neutral.c00};
 
   > div {
     &:hover {
@@ -50,7 +50,7 @@ const Bullets = styled.div<{ active?: number }>`
     position: relative;
     height: ${(p) => p.theme.space[1]}px;
     width: ${(p) => p.theme.space[8]}px;
-    background: ${(p) => p.theme.colors.palette.neutral.c00};
+    background: ${(p) => p.theme.colors.neutral.c00};
     opacity: 0.5;
     &:hover {
       opacity: 0.75;
@@ -77,7 +77,7 @@ const Close = styled.div`
   position: absolute;
   top: ${(p) => p.theme.space[7]}px;
   right: ${(p) => p.theme.space[5]}px;
-  color: ${(p) => p.theme.colors.palette.neutral.c00};
+  color: ${(p) => p.theme.colors.neutral.c00};
   &:hover {
     opacity: 0.5;
   }
@@ -167,22 +167,18 @@ const Carousel = ({
     <CarouselWrapper id={"carousel"} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
       {wantToDismiss ? (
         <DismissWrapper>
-          <Text color="palette.neutral.c00" fontWeight="medium" variant={"paragraph"}>
+          <Text color="neutral.c00" fontWeight="medium" variant={"paragraph"}>
             {dismissText}
           </Text>
           <Flex columnGap={5}>
-            <Button
-              color="palette.neutral.c100"
-              backgroundColor="palette.neutral.c00"
-              onClick={onDismiss}
-            >
+            <Button color="neutral.c100" backgroundColor="neutral.c00" onClick={onDismiss}>
               {dismissConfirmText}
             </Button>
             <Button
               outline
-              color="palette.neutral.c00"
-              backgroundColor="palette.neutral.c100"
-              borderColor="palette.neutral.c00"
+              color="neutral.c00"
+              backgroundColor="neutral.c100"
+              borderColor="neutral.c00"
               onClick={onCancelDismiss}
             >
               {dismissCancelText}

--- a/packages/react/src/components/cta/Button/Button.stories.tsx
+++ b/packages/react/src/components/cta/Button/Button.stories.tsx
@@ -55,7 +55,7 @@ export const Overview = (() => {
       {buttonVariants.flatMap((buttonType) =>
         [false, true].map((outline) => (
           <Flex flexDirection="row" alignItems="center" height="70px" columnGap={4}>
-            <Text variant="small" color="palette.neutral.c70">
+            <Text variant="small" color="neutral.c70">
               type="{buttonType}"<br />
               outline={`{${outline.toString()}}`}
               <br />
@@ -88,11 +88,11 @@ const Template = (args) => {
 const TemplateInverted = (args) => {
   return (
     <Flex flexDirection="column">
-      <Flex flex="0 0 1" p={4} alignItems="center" bg="palette.background.main">
+      <Flex flex="0 0 1" p={4} alignItems="center" bg="background.main">
         <Button {...args}>{args.children || "Regular button"}</Button>
       </Flex>
       <InvertTheme>
-        <Flex flex="0 0 1" p={4} alignItems="center" bg="palette.background.main">
+        <Flex flex="0 0 1" p={4} alignItems="center" bg="background.main">
           <Button {...args}>{args.children || "Inverted button"}</Button>
         </Flex>
       </InvertTheme>

--- a/packages/react/src/components/cta/Button/index.tsx
+++ b/packages/react/src/components/cta/Button/index.tsx
@@ -38,93 +38,93 @@ const IconContainer = styled.div<{
 const getVariantColors = (p: StyledProps<BaseProps>) => ({
   main: {
     outline: `
-        border-color: ${p.theme.colors.palette.neutral.c100};
-        color: ${p.theme.colors.palette.neutral.c100};
-        background-color: ${p.theme.colors.palette.neutral.c00};
+        border-color: ${p.theme.colors.neutral.c100};
+        color: ${p.theme.colors.neutral.c100};
+        background-color: ${p.theme.colors.neutral.c00};
         &:hover, &:focus {
-          background-color: ${p.theme.colors.palette.neutral.c20};
+          background-color: ${p.theme.colors.neutral.c20};
         }
         &:active {
-          background-color: ${p.theme.colors.palette.neutral.c30};
+          background-color: ${p.theme.colors.neutral.c30};
         }
       `,
     filled: `
-        color: ${p.theme.colors.palette.neutral.c00};
-        background-color: ${p.theme.colors.palette.neutral.c100};
+        color: ${p.theme.colors.neutral.c00};
+        background-color: ${p.theme.colors.neutral.c100};
         &:hover, &:focus {
-          background-color: ${p.theme.colors.palette.neutral.c90};
+          background-color: ${p.theme.colors.neutral.c90};
         }
       `,
   },
   shade: `
-      border-color: ${p.theme.colors.palette.neutral.c40};
-      color: ${p.theme.colors.palette.neutral.c100};
-      background-color: ${p.theme.colors.palette.neutral.c00};
+      border-color: ${p.theme.colors.neutral.c40};
+      color: ${p.theme.colors.neutral.c100};
+      background-color: ${p.theme.colors.neutral.c00};
       &:focus {
-        border-color: ${p.theme.colors.palette.primary.c80};
+        border-color: ${p.theme.colors.primary.c80};
       }
 
       &:hover, &:focus {
-        background-color: ${p.theme.colors.palette.neutral.c20};
+        background-color: ${p.theme.colors.neutral.c20};
       }
 
       &:active {
-        background-color: ${p.theme.colors.palette.neutral.c30};
+        background-color: ${p.theme.colors.neutral.c30};
       }
     `,
   error: {
     outline: `
-      border-color: ${p.theme.colors.palette.error.c100};
-      color: ${p.theme.colors.palette.error.c100};
-      background-color: ${p.theme.colors.palette.neutral.c00};
+      border-color: ${p.theme.colors.error.c100};
+      color: ${p.theme.colors.error.c100};
+      background-color: ${p.theme.colors.neutral.c00};
       &:hover {
-        background-color: ${p.theme.colors.palette.error.c10};
+        background-color: ${p.theme.colors.error.c10};
       }
       &:active {
-        background-color: ${p.theme.colors.palette.error.c30};
+        background-color: ${p.theme.colors.error.c30};
       }
     `,
     filled: `
-      color: ${p.theme.colors.palette.neutral.c00};
-      background-color: ${p.theme.colors.palette.error.c100};
+      color: ${p.theme.colors.neutral.c00};
+      background-color: ${p.theme.colors.error.c100};
       &:hover {
-        background-color: ${p.theme.colors.palette.error.c80};
+        background-color: ${p.theme.colors.error.c80};
       }
     `,
   },
   color: {
     outline: `
-      border-color: ${p.theme.colors.palette.primary.c80};
-      color: ${p.theme.colors.palette.primary.c80};
-      background-color: ${p.theme.colors.palette.neutral.c00};
+      border-color: ${p.theme.colors.primary.c80};
+      color: ${p.theme.colors.primary.c80};
+      background-color: ${p.theme.colors.neutral.c00};
       &:hover {
-        background-color: ${p.theme.colors.palette.primary.c10};
+        background-color: ${p.theme.colors.primary.c10};
       }
       &:active {
-        background-color: ${p.theme.colors.palette.primary.c20};
+        background-color: ${p.theme.colors.primary.c20};
       }
     `,
     filled: `
-      color: ${p.theme.colors.palette.neutral.c00};
-      background-color: ${p.theme.colors.palette.primary.c80};
+      color: ${p.theme.colors.neutral.c00};
+      background-color: ${p.theme.colors.primary.c80};
       &:hover {
-        background-color: ${p.theme.colors.palette.primary.c70};
+        background-color: ${p.theme.colors.primary.c70};
       }
     `,
   },
   disabled: {
     outline: `
-        border-color: ${p.theme.colors.palette.neutral.c50};
-        color: ${p.theme.colors.palette.neutral.c50};
-        background-color: ${p.theme.colors.palette.neutral.c00};
+        border-color: ${p.theme.colors.neutral.c50};
+        color: ${p.theme.colors.neutral.c50};
+        background-color: ${p.theme.colors.neutral.c00};
       `,
     filled: `
-        color: ${p.theme.colors.palette.neutral.c50};
-        background-color: ${p.theme.colors.palette.neutral.c30};
+        color: ${p.theme.colors.neutral.c50};
+        background-color: ${p.theme.colors.neutral.c30};
       `,
   },
   default: `
-    color: ${p.theme.colors.palette.neutral.c100};
+    color: ${p.theme.colors.neutral.c100};
     background-color: transparent;
     &:hover {
       text-decoration: underline;
@@ -166,7 +166,7 @@ export const Base = baseStyled.button.attrs((p: BaseProps) => ({
   position: relative;
   cursor: ${(p) => (p.disabled ? "default" : "pointer")};
   &:active {
-    box-shadow: 0 0 0 4px ${(p) => p.theme.colors.palette.primary.c60};
+    box-shadow: 0 0 0 4px ${(p) => p.theme.colors.primary.c60};
   }
 
   ${(p) => {

--- a/packages/react/src/components/form/BaseInput/index.tsx
+++ b/packages/react/src/components/form/BaseInput/index.tsx
@@ -44,25 +44,25 @@ export type InputContainerProps = React.ComponentProps<typeof InputContainer>;
 export const InputContainer = styled.div<Partial<CommonProps> & { focus?: boolean }>`
   display: flex;
   height: 48px;
-  border: ${(p) => `1px solid ${p.theme.colors.palette.neutral.c40}`};
+  border: ${(p) => `1px solid ${p.theme.colors.neutral.c40}`};
   border-radius: 24px;
   transition: all 0.2s ease;
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
 
   ${(p) =>
     p.focus &&
     !p.error &&
     !p.warning &&
     css`
-      border: 1px solid ${p.theme.colors.palette.primary.c80};
-      box-shadow: 0 0 0 4px ${rgba(p.theme.colors.palette.primary.c60, 0.48)};
+      border: 1px solid ${p.theme.colors.primary.c80};
+      box-shadow: 0 0 0 4px ${rgba(p.theme.colors.primary.c60, 0.48)};
     `};
 
   ${(p) =>
     p.error &&
     !p.disabled &&
     css`
-      border: 1px solid ${p.theme.colors.palette.error.c100};
+      border: 1px solid ${p.theme.colors.error.c100};
     `};
 
   ${(p) =>
@@ -70,7 +70,7 @@ export const InputContainer = styled.div<Partial<CommonProps> & { focus?: boolea
     p.warning &&
     !p.disabled &&
     css`
-      border: 1px solid ${p.theme.colors.palette.warning.c80};
+      border: 1px solid ${p.theme.colors.warning.c80};
     `};
 
   ${(p) =>
@@ -79,15 +79,15 @@ export const InputContainer = styled.div<Partial<CommonProps> & { focus?: boolea
     !p.disabled &&
     css`
       &:hover {
-        border: ${!p.disabled && `1px solid ${p.theme.colors.palette.primary.c80}`};
+        border: ${!p.disabled && `1px solid ${p.theme.colors.primary.c80}`};
       }
     `};
 
   ${(p) =>
     p.disabled &&
     css`
-      color: ${p.theme.colors.palette.neutral.c60};
-      background: ${(p) => p.theme.colors.palette.neutral.c20};
+      color: ${p.theme.colors.neutral.c60};
+      background: ${(p) => p.theme.colors.neutral.c20};
     `};
 `;
 
@@ -100,8 +100,7 @@ export const BaseInput = styled.input.attrs<
   height: 100%;
   width: 100%;
   border: 0;
-  caret-color: ${(p) =>
-    p.error ? p.theme.colors.palette.error.c100 : p.theme.colors.palette.primary.c80};
+  caret-color: ${(p) => (p.error ? p.theme.colors.error.c100 : p.theme.colors.primary.c80)};
   background: none;
   outline: none;
   cursor: ${(p) => (p.disabled ? "not-allowed" : "text")};
@@ -111,8 +110,7 @@ export const BaseInput = styled.input.attrs<
   padding-left: 20px;
   padding-right: 20px;
   &::placeholder {
-    color: ${(p) =>
-      p.disabled ? p.theme.colors.palette.neutral.c50 : p.theme.colors.palette.neutral.c70};
+    color: ${(p) => (p.disabled ? p.theme.colors.neutral.c50 : p.theme.colors.neutral.c70)};
   }
 
   /* Hide type=number arrow for Chrome, Safari, Edge, Opera */
@@ -131,11 +129,11 @@ export const BaseInput = styled.input.attrs<
 `;
 
 export const InputErrorContainer = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.error.c100};
+  color: ${(p) => p.theme.colors.error.c100};
   margin-left: 12px;
 `;
 export const InputWarningContainer = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.warning.c80};
+  color: ${(p) => p.theme.colors.warning.c80};
   margin-left: 12px;
 `;
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -20,7 +20,7 @@ const Input = styled.input`
   width: ${(p) => p.theme.space[7]}px;
   height: ${(p) => p.theme.space[7]}px;
   appearance: none;
-  border: 1px solid ${(props) => props.theme.colors.palette.neutral.c90};
+  border: 1px solid ${(props) => props.theme.colors.neutral.c90};
   box-shadow: none;
 
   &:checked {
@@ -46,7 +46,7 @@ const Input = styled.input`
 `;
 
 const Label = styled(Text).attrs({ type: "body", fontWeight: "500" })`
-  color: ${(props) => props.theme.colors.palette.neutral.c80};
+  color: ${(props) => props.theme.colors.neutral.c80};
 
   /* Version when the input is checked */
   ${Input}:checked + & {
@@ -60,7 +60,7 @@ const Label = styled(Text).attrs({ type: "body", fontWeight: "500" })`
 
 const Container = styled.div`
   --ll-checkbox-color: unset;
-  color: var(--ll-checkbox-color, ${(props) => props.theme.colors.palette.primary.c90});
+  color: var(--ll-checkbox-color, ${(props) => props.theme.colors.primary.c90});
 
   display: inline-flex;
   column-gap: ${(p) => p.theme.space[5]}px;
@@ -68,19 +68,19 @@ const Container = styled.div`
   cursor: pointer;
 
   &[data-variant="default"] {
-    --ll-checkbox-color: ${(props) => props.theme.colors.palette.primary.c90};
+    --ll-checkbox-color: ${(props) => props.theme.colors.primary.c90};
   }
 
   &[data-variant="success"] {
-    --ll-checkbox-color: ${(props) => props.theme.colors.palette.success.c100};
+    --ll-checkbox-color: ${(props) => props.theme.colors.success.c100};
   }
 
   &[data-variant="error"] {
-    --ll-checkbox-color: ${(props) => props.theme.colors.palette.error.c100};
+    --ll-checkbox-color: ${(props) => props.theme.colors.error.c100};
   }
 
   &[data-disabled="true"] {
-    --ll-checkbox-color: ${(props) => props.theme.colors.palette.neutral.c80};
+    --ll-checkbox-color: ${(props) => props.theme.colors.neutral.c80};
     cursor: unset;
   }
 `;

--- a/packages/react/src/components/form/Dropdown/index.tsx
+++ b/packages/react/src/components/form/Dropdown/index.tsx
@@ -17,7 +17,7 @@ function DropdownControl<T, M extends boolean = false>(props: ControlProps<T, M>
 
   return (
     <components.Control {...props}>
-      <Text fontWeight="semiBold" variant={"paragraph"} color="palette.neutral.c80" mr={2}>
+      <Text fontWeight="semiBold" variant={"paragraph"} color="neutral.c80" mr={2}>
         {label}
       </Text>
       {children}
@@ -62,7 +62,7 @@ export default function Dropdown(props: Props): JSX.Element {
       styles={{
         singleValue: (provided) => ({
           ...provided,
-          color: theme.colors.palette.neutral.c100,
+          color: theme.colors.neutral.c100,
           margin: 0,
           top: undefined,
           position: undefined,

--- a/packages/react/src/components/form/LegendInput/index.tsx
+++ b/packages/react/src/components/form/LegendInput/index.tsx
@@ -6,10 +6,10 @@ import styled from "styled-components";
 export type Props = InputProps & { legend: string };
 
 const Legend = styled(Text)`
-  color: ${(props) => props.theme.colors.palette.neutral.c70};
+  color: ${(props) => props.theme.colors.neutral.c70};
 
   &[data-disabled="true"] {
-    color: ${(props) => props.theme.colors.palette.neutral.c50};
+    color: ${(props) => props.theme.colors.neutral.c50};
   }
 `;
 

--- a/packages/react/src/components/form/NumberInput/index.tsx
+++ b/packages/react/src/components/form/NumberInput/index.tsx
@@ -6,10 +6,8 @@ import styled from "styled-components";
 
 // TODO: Replace me with a real button as soon as they are designed
 const MaxButton = styled.button<{ active?: boolean }>`
-  color: ${(p) =>
-    p.active ? p.theme.colors.palette.neutral.c00 : p.theme.colors.palette.neutral.c70};
-  background-color: ${(p) =>
-    p.active ? p.theme.colors.palette.neutral.c100 : p.theme.colors.palette.neutral.c00};
+  color: ${(p) => (p.active ? p.theme.colors.neutral.c00 : p.theme.colors.neutral.c70)};
+  background-color: ${(p) => (p.active ? p.theme.colors.neutral.c100 : p.theme.colors.neutral.c00)};
   border-radius: 100px;
   border-width: 0;
   height: 31px;
@@ -18,8 +16,8 @@ const MaxButton = styled.button<{ active?: boolean }>`
   cursor: pointer;
 
   &:disabled {
-    color: ${(p) => p.theme.colors.palette.neutral.c50};
-    background-color: ${(p) => (p.active ? p.theme.colors.palette.neutral.c30 : "transparent")};
+    color: ${(p) => p.theme.colors.neutral.c50};
+    background-color: ${(p) => (p.active ? p.theme.colors.neutral.c30 : "transparent")};
     cursor: unset;
   }
 `;

--- a/packages/react/src/components/form/QrCodeInput/index.tsx
+++ b/packages/react/src/components/form/QrCodeInput/index.tsx
@@ -12,13 +12,13 @@ const QrCodeButton = styled.button`
   height: 32px;
   border-radius: 50%;
   border-width: 0;
-  color: ${(p) => p.theme.colors.palette.neutral.c00};
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c00};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
   cursor: pointer;
 
   &:disabled {
-    background-color: ${(p) => p.theme.colors.palette.neutral.c30};
-    color: ${(p) => p.theme.colors.palette.neutral.c50};
+    background-color: ${(p) => p.theme.colors.neutral.c30};
+    color: ${(p) => p.theme.colors.neutral.c50};
     cursor: unset;
   }
 `;

--- a/packages/react/src/components/form/QuantityInput/index.tsx
+++ b/packages/react/src/components/form/QuantityInput/index.tsx
@@ -5,8 +5,8 @@ import Text from "../../asorted/Text";
 import styled from "styled-components";
 
 const MaxButton = styled.button`
-  color: ${(p) => p.theme.colors.palette.neutral.c00};
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c00};
+  background-color: ${(p) => p.theme.colors.neutral.c100};
   border-radius: 100px;
   border-width: 0;
   padding-left: 14px;
@@ -15,17 +15,17 @@ const MaxButton = styled.button`
   cursor: pointer;
 
   &:disabled {
-    background-color: ${(p) => p.theme.colors.palette.neutral.c30};
-    color: ${(p) => p.theme.colors.palette.neutral.c50};
+    background-color: ${(p) => p.theme.colors.neutral.c30};
+    color: ${(p) => p.theme.colors.neutral.c50};
     cursor: unset;
   }
 `;
 
 const Legend = styled(Text)`
-  color: ${(p) => p.theme.colors.palette.neutral.c70};
+  color: ${(p) => p.theme.colors.neutral.c70};
 
   &[data-disabled="true"] {
-    color: ${(p) => p.theme.colors.palette.neutral.c50};
+    color: ${(p) => p.theme.colors.neutral.c50};
   }
 `;
 

--- a/packages/react/src/components/form/Radio/RadioElement.tsx
+++ b/packages/react/src/components/form/Radio/RadioElement.tsx
@@ -6,11 +6,11 @@ import Text from "../../asorted/Text";
 import { RadioContext } from "./index";
 
 const Label = styled(Text)`
-  color: var(--ledger-ui-checkbox-color, ${(p) => p.theme.colors.palette.neutral.c100});
+  color: var(--ledger-ui-checkbox-color, ${(p) => p.theme.colors.neutral.c100});
 `;
 
 const Input = styled.input`
-  --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.neutral.c50};
+  --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c50};
   --ledger-ui-checkbox-size: 1.25rem;
 
   position: relative;
@@ -38,17 +38,17 @@ const Input = styled.input`
 
   &[data-variant="default"] {
     :hover {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.primary.c90};
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.primary.c90};
     }
     :active {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.primary.c100};
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.primary.c100};
     }
     :checked,
     :focus {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.primary.c80};
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.primary.c80};
     }
     :focus {
-      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.palette.primary.c60, 0.48)};
+      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.primary.c60, 0.48)};
     }
   }
 
@@ -56,10 +56,10 @@ const Input = styled.input`
     :hover,
     :checked:not([disabled]),
     :checked:not([disabled]) + ${Label}, :focus {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.success.c100};
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.success.c100};
     }
     :focus {
-      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.palette.success.c100, 0.48)};
+      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.success.c100, 0.48)};
     }
   }
 
@@ -67,17 +67,17 @@ const Input = styled.input`
     :hover,
     :checked:not([disabled]),
     :checked:not([disabled]) + ${Label}, :focus {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.error.c100};
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.error.c100};
     }
     :focus {
-      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.palette.error.c100, 0.48)};
+      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.error.c100, 0.48)};
     }
   }
 
   &[data-variant]:disabled {
-    --ledger-ui-checkbox-color: ${(p) => p.theme.colors.palette.neutral.c40};
+    --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c40};
     cursor: unset;
-    background-color: ${(p) => p.theme.colors.palette.neutral.c30};
+    background-color: ${(p) => p.theme.colors.neutral.c30};
   }
 `;
 

--- a/packages/react/src/components/form/Radio/RadioListElement.tsx
+++ b/packages/react/src/components/form/Radio/RadioListElement.tsx
@@ -13,24 +13,23 @@ type ElementState = {
 export const Label = styled(Text)<ElementState>`
   color: ${(p) =>
     p.disabled
-      ? p.theme.colors.palette.neutral.c50
+      ? p.theme.colors.neutral.c50
       : p.checked
-      ? p.theme.colors.palette.primary.c90
-      : p.theme.colors.palette.neutral.c100};
+      ? p.theme.colors.primary.c90
+      : p.theme.colors.neutral.c100};
 `;
 
 const Container = styled(Flex)<ElementState>`
   cursor: ${(p) => (p.disabled ? "" : "pointer")};
   justify-content: center;
   align-items: center;
-  background-color: ${(p) => (p.checked ? p.theme.colors.palette.primary.c20 : "")};
-  border: 1px solid
-    ${(p) => (p.checked ? p.theme.colors.palette.primary.c50 : p.theme.colors.palette.neutral.c40)};
+  background-color: ${(p) => (p.checked ? p.theme.colors.primary.c20 : "")};
+  border: 1px solid ${(p) => (p.checked ? p.theme.colors.primary.c50 : p.theme.colors.neutral.c40)};
   border-radius: ${(p) => `${p.theme.radii[2]}px`};
   padding: ${(p) => p.theme.space[6]}px;
 
   :hover {
-    border-color: ${(p) => (p.disabled || p.checked ? "" : p.theme.colors.palette.primary.c80)};
+    border-color: ${(p) => (p.disabled || p.checked ? "" : p.theme.colors.primary.c80)};
   }
 `;
 
@@ -38,7 +37,7 @@ const Input = styled.input`
   position: relative;
   appearance: none;
   &:focus ~ ${Container} {
-    box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.palette.primary.c60, 0.48)};
+    box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.primary.c60, 0.48)};
   }
 `;
 

--- a/packages/react/src/components/form/SearchInput/index.tsx
+++ b/packages/react/src/components/form/SearchInput/index.tsx
@@ -12,9 +12,7 @@ export default function SearchInput(props: InputProps): JSX.Element {
       renderLeft={
         <InputRenderLeftContainer>
           <SearchMedium
-            color={
-              props.disabled ? theme.colors.palette.neutral.c50 : theme.colors.palette.neutral.c70
-            }
+            color={props.disabled ? theme.colors.neutral.c50 : theme.colors.neutral.c70}
           />
         </InputRenderLeftContainer>
       }

--- a/packages/react/src/components/form/SelectInput/DropdownIndicator.tsx
+++ b/packages/react/src/components/form/SelectInput/DropdownIndicator.tsx
@@ -22,7 +22,7 @@ export function DropdownIndicator<
   const { isDisabled } = props.selectProps;
 
   const ChevronIcon = props.selectProps.menuIsOpen ? ChevronTopMedium : ChevronBottomMedium;
-  const color = isDisabled ? theme.colors.palette.neutral.c60 : theme.colors.palette.neutral.c100;
+  const color = isDisabled ? theme.colors.neutral.c60 : theme.colors.neutral.c100;
 
   return (
     <components.DropdownIndicator {...props}>

--- a/packages/react/src/components/form/SelectInput/MenuList.tsx
+++ b/packages/react/src/components/form/SelectInput/MenuList.tsx
@@ -12,11 +12,11 @@ export function getStyles<
     flexDirection: "column",
     gap: theme.space[2],
     padding: theme.space[3],
-    border: `1px solid ${theme.colors.palette.neutral.c20}`,
+    border: `1px solid ${theme.colors.neutral.c20}`,
     borderRadius: "8px",
     boxShadow: `0px 2px 12px rgba(0, 0, 0, 0.04)`,
-    background: theme.colors.palette.neutral.c00,
-    color: theme.colors.palette.neutral.c80,
+    background: theme.colors.neutral.c00,
+    color: theme.colors.neutral.c80,
   });
 }
 

--- a/packages/react/src/components/form/SelectInput/Option.tsx
+++ b/packages/react/src/components/form/SelectInput/Option.tsx
@@ -35,37 +35,37 @@ const Wrapper = styled(Text).attrs({ as: "div" })<{
     const { theme, selected, focus, disabled } = props;
     if (selected) {
       return `
-        color: ${theme.colors.palette.primary.c90};
-        background: ${theme.colors.palette.primary.c20};
+        color: ${theme.colors.primary.c90};
+        background: ${theme.colors.primary.c20};
       `;
     }
     if (disabled) {
       return `
-        color: ${theme.colors.palette.neutral.c50};
+        color: ${theme.colors.neutral.c50};
         ${
           focus
             ? `&:not(:active) {
-            background: ${theme.colors.palette.neutral.c20};
+            background: ${theme.colors.neutral.c20};
           }`
             : ""
         }
       `;
     }
     return `
-      color: ${theme.colors.palette.neutral.c80};
+      color: ${theme.colors.neutral.c80};
       &:hover {
-        color: ${theme.colors.palette.neutral.c100};
-        background: ${theme.colors.palette.primary.c10};
+        color: ${theme.colors.neutral.c100};
+        background: ${theme.colors.primary.c10};
       }
       &:active {
-        color: ${theme.colors.palette.neutral.c100};
-        background: ${theme.colors.palette.primary.c30};
+        color: ${theme.colors.neutral.c100};
+        background: ${theme.colors.primary.c30};
       }
       ${
         focus
           ? `&:not(:active) {
-          color: ${theme.colors.palette.neutral.c100};
-          background: ${theme.colors.palette.primary.c10};
+          color: ${theme.colors.neutral.c100};
+          background: ${theme.colors.primary.c10};
         }`
           : ""
       }

--- a/packages/react/src/components/form/SelectInput/Select.stories.tsx
+++ b/packages/react/src/components/form/SelectInput/Select.stories.tsx
@@ -390,9 +390,7 @@ export const SideRenders: StoryTemplate<Props> = (args) => {
       onChange={setValue}
       renderLeft={(props) => (
         <Flex mr={3}>
-          <SearchMedium
-            color={props.isDisabled ? "currentColor" : theme["colors"].palette.neutral.c70}
-          />
+          <SearchMedium color={props.isDisabled ? "currentColor" : theme.colors.neutral.c70} />
         </Flex>
       )}
       renderRight={() => (

--- a/packages/react/src/components/form/SelectInput/ValueContainer.tsx
+++ b/packages/react/src/components/form/SelectInput/ValueContainer.tsx
@@ -23,7 +23,7 @@ export function ValueContainer<
   T extends OptionTypeBase = { label: string; value: string },
   M extends boolean = false,
 >(props: ValueContainerProps<T, M> & ExtraProps<T, M>): JSX.Element {
-  const color = props.selectProps.isDisabled ? "palette.neutral.c60" : "palette.neutral.c100";
+  const color = props.selectProps.isDisabled ? "neutral.c60" : "neutral.c100";
   return (
     <components.ValueContainer {...props}>
       <Text as="div" variant="paragraph" color={color}>

--- a/packages/react/src/components/form/SelectInput/index.tsx
+++ b/packages/react/src/components/form/SelectInput/index.tsx
@@ -44,11 +44,11 @@ const stylesFn = <
   option: OptionModule.getStyles(),
   input: (provided) => ({
     ...provided,
-    color: theme.colors.palette.neutral.c100,
+    color: theme.colors.neutral.c100,
   }),
   placeholder: (provided) => ({
     ...provided,
-    color: theme.colors.palette.neutral.c60,
+    color: theme.colors.neutral.c60,
   }),
   singleValue: (provided) => ({
     ...provided,

--- a/packages/react/src/components/form/SplitInput/index.tsx
+++ b/packages/react/src/components/form/SplitInput/index.tsx
@@ -25,20 +25,20 @@ type DividerProps = {
 };
 function getDividerColor(props: DividerProps) {
   if (props.disabled) {
-    return props.theme?.colors.palette.neutral.c40;
+    return props.theme?.colors.neutral.c40;
   }
   if (props.error) {
-    return props.theme?.colors.palette.error.c100;
+    return props.theme?.colors.error.c100;
   }
   if (props.focus) {
-    return props.theme?.colors.palette.primary.c80;
+    return props.theme?.colors.primary.c80;
   }
 
-  return props.theme?.colors.palette.neutral.c40;
+  return props.theme?.colors.neutral.c40;
 }
 
 function getHoverBolderColor(props: DividerProps) {
-  return props.disabled || props.error ? "inherit" : props.theme?.colors.palette.primary.c80;
+  return props.disabled || props.error ? "inherit" : props.theme?.colors.primary.c80;
 }
 
 const Divider = styled.div<{

--- a/packages/react/src/components/form/Switch/Switch.tsx
+++ b/packages/react/src/components/form/Switch/Switch.tsx
@@ -37,7 +37,7 @@ const Switcher = styled.div`
   position: relative;
   display: inline-block;
 
-  background: ${(props) => props.theme.colors.palette.neutral.c60};
+  background: ${(props) => props.theme.colors.neutral.c60};
   border-radius: ${(p) => p.theme.space[6]}px;
   width: var(--ll-switch-width);
   height: var(--ll-switch-height);
@@ -51,7 +51,7 @@ const Switcher = styled.div`
 
   &:focus {
     outline-style: auto;
-    outline: 1px solid ${(props) => props.theme.colors.palette.neutral.c90};
+    outline: 1px solid ${(props) => props.theme.colors.neutral.c90};
     outline-offset: ${(p) => p.theme.space[1]}px;
   }
 
@@ -59,7 +59,7 @@ const Switcher = styled.div`
   &:before {
     position: absolute;
     display: block;
-    background: ${(props) => props.theme.colors.palette.constant.white};
+    background: ${(props) => props.theme.colors.constant.white};
     border-radius: ${(p) => p.theme.space[12]}px;
 
     width: calc(calc(var(--ll-switch-width) / 2) - var(--ll-switch-padding));
@@ -76,27 +76,27 @@ const Switcher = styled.div`
   }
 
   &:hover {
-    background-color: ${(props) => props.theme.colors.palette.neutral.c70};
+    background-color: ${(props) => props.theme.colors.neutral.c70};
   }
 
   &:active {
-    background-color: ${(props) => props.theme.colors.palette.neutral.c80};
+    background-color: ${(props) => props.theme.colors.neutral.c80};
   }
 
   /* CHECKED VARIANT */
   ${Input}:checked ~ & {
-    background: ${(props) => props.theme.colors.palette.primary.c80};
+    background: ${(props) => props.theme.colors.primary.c80};
 
     &:before {
       transform: translateX(calc(var(--ll-switch-width) / 2));
     }
 
     &:hover {
-      background: ${(props) => props.theme.colors.palette.primary.c90};
+      background: ${(props) => props.theme.colors.primary.c90};
     }
 
     :active {
-      background: ${(props) => props.theme.colors.palette.primary.c100};
+      background: ${(props) => props.theme.colors.primary.c100};
     }
   }
 `;

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -12,7 +12,7 @@ const Container = styled(FlexBox)`
   width: 100%;
   height: 100%;
   flex-direction: column;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c00};
+  background-color: ${(p) => p.theme.colors.neutral.c00};
   padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
 `;
 const Header = styled(FlexBox)`
@@ -45,7 +45,7 @@ const Overlay = styled.div`
   width: 100vw;
   height: 100vh;
   z-index: 999;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c100a07};
+  background-color: ${(p) => p.theme.colors.neutral.c100a07};
 `;
 const ScrollWrapper = styled.div`
   overflow: scroll;
@@ -63,7 +63,7 @@ const Button = styled.button`
   background: unset;
   border: unset;
   cursor: pointer;
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
 `;
 
 export interface DrawerProps {

--- a/packages/react/src/components/layout/Popin/index.tsx
+++ b/packages/react/src/components/layout/Popin/index.tsx
@@ -37,7 +37,7 @@ const Wrapper = styled(Flex).attrs<FlexBoxProps>((p) => ({
   zIndex: p.theme.zIndexes[8],
   p: p.p !== undefined ? p.p : p.theme.space[10],
   rowGap: 6,
-  backgroundColor: p.theme.colors.palette.neutral.c00,
+  backgroundColor: p.theme.colors.neutral.c00,
 }))``;
 
 const Overlay = styled(Flex).attrs((p) => ({
@@ -49,7 +49,7 @@ const Overlay = styled(Flex).attrs((p) => ({
   position: "fixed",
   top: 0,
   left: 0,
-  backgroundColor: p.theme.colors.palette.neutral.c100a07,
+  backgroundColor: p.theme.colors.neutral.c100a07,
 }))``;
 
 const Header = baseStyled.section`
@@ -81,7 +81,7 @@ const PopinHeader = ({ children, onClose, onBack, ...props }: PopinHeaderProps) 
     <Flex>
       {onBack ? (
         <IconContainer onClick={onBack}>
-          <ArrowLeftIcon size={ICON_SIZE} color="palette.neutral.c100" />
+          <ArrowLeftIcon size={ICON_SIZE} color="neutral.c100" />
         </IconContainer>
       ) : null}
     </Flex>
@@ -89,7 +89,7 @@ const PopinHeader = ({ children, onClose, onBack, ...props }: PopinHeaderProps) 
     <Flex>
       {onClose ? (
         <IconContainer onClick={onClose}>
-          <CloseIcon size={ICON_SIZE} color="palette.neutral.c100" />
+          <CloseIcon size={ICON_SIZE} color="neutral.c100" />
         </IconContainer>
       ) : null}
     </Flex>

--- a/packages/react/src/components/loaders/ProgressLoader/index.tsx
+++ b/packages/react/src/components/loaders/ProgressLoader/index.tsx
@@ -30,15 +30,15 @@ const StyledCircle = styled.circle.attrs({
 `;
 
 const StyledCircleBackground = styled(StyledCircle).attrs((props) => ({
-  stroke: props.theme.colors.palette.primary.c20,
+  stroke: props.theme.colors.primary.c20,
 }))``;
 
 const StyledCircleFront = styled(StyledCircle).attrs((props) => ({
-  stroke: props.theme.colors.palette.primary.c60,
+  stroke: props.theme.colors.primary.c60,
 }))``;
 
 const StyledCenteredText = styled(Text).attrs({
-  color: "palette.primary.c80",
+  color: "primary.c80",
 })`
   position: absolute;
   top: 50%;

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -30,19 +30,19 @@ const StyledAlertContainer = styled.div<{ type?: AlertType }>`
     switch (p.type) {
       case "warning":
         return css`
-          background: ${p.theme.colors.palette.warning.c30};
-          color: ${p.theme.colors.palette.warning.c100};
+          background: ${p.theme.colors.warning.c30};
+          color: ${p.theme.colors.warning.c100};
         `;
       case "error":
         return css`
-          background: ${p.theme.colors.palette.error.c30};
-          color: ${p.theme.colors.palette.error.c100};
+          background: ${p.theme.colors.error.c30};
+          color: ${p.theme.colors.error.c100};
         `;
       case "info":
       default:
         return css`
-          background: ${p.theme.colors.palette.primary.c20};
-          color: ${p.theme.colors.palette.primary.c90};
+          background: ${p.theme.colors.primary.c20};
+          color: ${p.theme.colors.primary.c90};
         `;
     }
   }}

--- a/packages/react/src/components/message/Log/index.tsx
+++ b/packages/react/src/components/message/Log/index.tsx
@@ -12,7 +12,7 @@ const Container = styled(FlexBox)`
   flex-wrap: wrap;
   align-items: stretch;
   min-height: ${(p) => p.theme.space[12]}px;
-  color: ${(p) => p.theme.colors.palette.neutral.c100};
+  color: ${(p) => p.theme.colors.neutral.c100};
 `;
 
 const TextContainer = styled(FlexBox).attrs(() => ({

--- a/packages/react/src/components/message/Notification/Badge.stories.tsx
+++ b/packages/react/src/components/message/Notification/Badge.stories.tsx
@@ -23,14 +23,14 @@ export const Badge = (args: Props): JSX.Element => {
     <FlexBox style={{ columnGap: "2em" }}>
       <BadgeComponent
         {...args}
-        color="palette.warning.c100"
-        backgroundColor="palette.warning.c10"
+        color="warning.c100"
+        backgroundColor="warning.c10"
         icon={<Icon name="Warning" size={24} />}
       />
       <BadgeComponent
         {...args}
-        color="palette.primary.c100"
-        backgroundColor="palette.primary.c10"
+        color="primary.c100"
+        backgroundColor="primary.c10"
         icon={<Icon name="Info" size={24} weight="Medium" />}
       />
     </FlexBox>

--- a/packages/react/src/components/message/Notification/Badge.tsx
+++ b/packages/react/src/components/message/Notification/Badge.tsx
@@ -10,14 +10,14 @@ const ActiveCircle = styled.div`
   width: 10px;
   border-radius: 9999px;
   box-sizing: content-box;
-  background-color: ${(p) => p.theme.colors.palette.error.c100};
+  background-color: ${(p) => p.theme.colors.error.c100};
 
   border: 2px solid
     var(
       --notification-badge-border,
       ${(p) => {
         /* The CSS variable is dynamically set by the Notification component */
-        return p.theme.colors.palette.background.main;
+        return p.theme.colors.background.main;
       }}
     );
 `;

--- a/packages/react/src/components/message/Notification/Notification.stories.tsx
+++ b/packages/react/src/components/message/Notification/Notification.stories.tsx
@@ -39,8 +39,8 @@ export function Notifications(args: Props & { active: boolean }): JSX.Element {
 
   const warningBadge = (
     <Notification.Badge
-      color="palette.warning.c100"
-      backgroundColor="palette.warning.c10"
+      color="warning.c100"
+      backgroundColor="warning.c10"
       icon={<Icon name="Warning" size={24} />}
       active={args.active}
     />
@@ -48,8 +48,8 @@ export function Notifications(args: Props & { active: boolean }): JSX.Element {
 
   const infoBadge = (
     <Notification.Badge
-      color="palette.primary.c100"
-      backgroundColor="palette.primary.c10"
+      color="primary.c100"
+      backgroundColor="primary.c10"
       icon={<Icon name="Info" size={24} weight="Medium" />}
       active={args.active}
     />

--- a/packages/react/src/components/message/Notification/index.tsx
+++ b/packages/react/src/components/message/Notification/index.tsx
@@ -31,12 +31,9 @@ const Container = styled(FlexBox).attrs<ContainerProps>({
 })<ContainerProps>`
   --notification-badge-border: ${(p) => {
     /* Set a CSS variable that will be consumed by the Badge component */
-    return p.hasBackground
-      ? p.theme.colors.palette.neutral.c30
-      : p.theme.colors.palette.background.main;
+    return p.hasBackground ? p.theme.colors.neutral.c30 : p.theme.colors.background.main;
   }};
-  background-color: ${(p) =>
-    p.hasBackground ? p.theme.colors.palette.neutral.c30 : "transparent"};
+  background-color: ${(p) => (p.hasBackground ? p.theme.colors.neutral.c30 : "transparent")};
 
   border-radius: 8px;
 `;
@@ -54,16 +51,11 @@ function Notification({
     <Container hasBackground={hasBackground} {...containerProps}>
       {badge}
       <FlexBox flexDirection="column" rowGap={3} flex="auto">
-        <Text variant={"large"} fontWeight="medium" color="palette.neutral.c100">
+        <Text variant={"large"} fontWeight="medium" color="neutral.c100">
           {title}
         </Text>
         {description && (
-          <Text
-            variant={"paragraph"}
-            fontWeight="medium"
-            color="palette.neutral.c80"
-            whiteSpace="pre-wrap"
-          >
+          <Text variant={"paragraph"} fontWeight="medium" color="neutral.c80" whiteSpace="pre-wrap">
             {description}
           </Text>
         )}

--- a/packages/react/src/components/message/StatusNotification/StatusNotification.stories.tsx
+++ b/packages/react/src/components/message/StatusNotification/StatusNotification.stories.tsx
@@ -27,8 +27,8 @@ export default {
 export function StatusNotifications(args: Props & { active: boolean }): JSX.Element {
   const { ...props } = args;
 
-  const warningBadge = <Icon name="Warning" size={50} color="palette.error.c100" weight="Light" />;
-  const infoBadge = <Icon name="Info" size={50} color="palette.primary.c100" weight="Regular" />;
+  const warningBadge = <Icon name="Warning" size={50} color="error.c100" weight="Light" />;
+  const infoBadge = <Icon name="Info" size={50} color="primary.c100" weight="Regular" />;
 
   return (
     <FlexBox justifyContent="center">

--- a/packages/react/src/components/message/StatusNotification/index.tsx
+++ b/packages/react/src/components/message/StatusNotification/index.tsx
@@ -24,7 +24,7 @@ const Container = styled(FlexBox).attrs<ContainerProps>({
   border-width: 1px;
   border-style: ${(p) => (p.hasBorder ? "solid" : "none")};
   border-radius: 8px;
-  border-color: ${(p) => p.theme.colors.palette.neutral.c40};
+  border-color: ${(p) => p.theme.colors.neutral.c40};
 `;
 
 function StatusNotification({

--- a/packages/react/src/components/message/Tip/index.tsx
+++ b/packages/react/src/components/message/Tip/index.tsx
@@ -22,19 +22,19 @@ const StyledIconContainer = styled.div<{ type?: TipType }>`
     switch (p.type) {
       case "warning":
         return css`
-          background: ${p.theme.colors.palette.warning.c10};
-          color: ${p.theme.colors.palette.warning.c100};
+          background: ${p.theme.colors.warning.c10};
+          color: ${p.theme.colors.warning.c100};
         `;
       case "error":
         return css`
-          background: ${p.theme.colors.palette.error.c10};
-          color: ${p.theme.colors.palette.error.c100};
+          background: ${p.theme.colors.error.c10};
+          color: ${p.theme.colors.error.c100};
         `;
       case "success":
       default:
         return css`
-          background: ${p.theme.colors.palette.success.c30};
-          color: ${p.theme.colors.palette.success.c100};
+          background: ${p.theme.colors.success.c30};
+          color: ${p.theme.colors.success.c100};
         `;
     }
   }}
@@ -50,12 +50,7 @@ export default function Tip({ type, label }: TipProps): JSX.Element {
   return (
     <Flex alignItems={"center"}>
       {type && <StyledIconContainer type={type}>{icons[type]}</StyledIconContainer>}
-      <Text
-        variant={"paragraph"}
-        fontWeight={"medium"}
-        color={"palette.neutral.c100"}
-        flexShrink={1}
-      >
+      <Text variant={"paragraph"} fontWeight={"medium"} color={"neutral.c100"} flexShrink={1}>
         {label}
       </Text>
     </Flex>

--- a/packages/react/src/components/message/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/message/Tooltip/Tooltip.stories.tsx
@@ -80,7 +80,7 @@ export const Tooltip: StoryTemplate<Props> = (args) => (
         <Text
           as="div"
           fontWeight="semiBold"
-          color="palette.neutral.c100"
+          color="neutral.c100"
           style={{ border: "2px solid #AAA", borderRadius: "5px" }}
           p={10}
           textAlign="center"

--- a/packages/react/src/components/message/Tooltip/index.tsx
+++ b/packages/react/src/components/message/Tooltip/index.tsx
@@ -58,7 +58,7 @@ export default function Tooltip(props: Props): JSX.Element | null {
       {...rest}
       placement={placement}
       content={
-        <Text fontWeight="medium" variant={"paragraph"} color="palette.neutral.c00">
+        <Text fontWeight="medium" variant={"paragraph"} color="neutral.c00">
           {content}
         </Text>
       }

--- a/packages/react/src/components/message/Tooltip/styles.ts
+++ b/packages/react/src/components/message/Tooltip/styles.ts
@@ -13,8 +13,8 @@ export default css`
 
   .tippy-box {
     position: relative;
-    background-color: ${(p: Props) => p.theme.colors.palette.neutral.c100};
-    color: ${(p: Props) => p.theme.colors.palette.neutral.c00};
+    background-color: ${(p: Props) => p.theme.colors.neutral.c100};
+    color: ${(p: Props) => p.theme.colors.neutral.c00};
     border-radius: 4px;
     font-size: 14px;
     line-height: 1.4;
@@ -75,7 +75,7 @@ export default css`
   .tippy-arrow {
     width: 16px;
     height: 16px;
-    color: ${(p: Props) => p.theme.colors.palette.neutral.c100};
+    color: ${(p: Props) => p.theme.colors.neutral.c100};
   }
 
   .tippy-arrow:before {

--- a/packages/react/src/components/navigation/Aside/Aside.stories.tsx
+++ b/packages/react/src/components/navigation/Aside/Aside.stories.tsx
@@ -45,19 +45,13 @@ export function Aside(args: Props): JSX.Element {
         footer={footer}
         p={10}
         width="324px"
-        backgroundColor="palette.primary.c60"
+        backgroundColor="primary.c60"
       >
         <FlexBox m={-10}>
           <img src={nanoIllustration} />
         </FlexBox>
       </AsideComponent>
-      <AsideComponent
-        {...args}
-        header={header}
-        p={10}
-        backgroundColor="palette.primary.c60"
-        flex={1}
-      >
+      <AsideComponent {...args} header={header} p={10} backgroundColor="primary.c60" flex={1}>
         <FlexBox justifyContent="center">
           <img src={keyboardIllustration} />
         </FlexBox>

--- a/packages/react/src/components/navigation/Breadcrumb/index.tsx
+++ b/packages/react/src/components/navigation/Breadcrumb/index.tsx
@@ -19,14 +19,14 @@ export type Segment = Element | Elements;
 const Link = styled(Text).attrs({
   ff: "Inter|SemiBold",
   fontSize: 3,
-  color: "palette.neutral.c80",
+  color: "neutral.c80",
   tabIndex: 0,
 })`
   cursor: pointer;
   :hover,
   :active,
   :focus {
-    color: ${(p) => p.theme.colors.palette.neutral.c100};
+    color: ${(p) => p.theme.colors.neutral.c100};
     text-decoration: underline;
   }
 `;
@@ -44,7 +44,7 @@ export default memo(function Breadcrumb({ segments, onChange }: Props): JSX.Elem
       renderArray.push(
         <>
           {index > 0 ? (
-            <Text fontWeight="semiBold" color="palette.neutral.c40" variant={"paragraph"}>
+            <Text fontWeight="semiBold" color="neutral.c40" variant={"paragraph"}>
               /
             </Text>
           ) : null}
@@ -67,9 +67,9 @@ export default memo(function Breadcrumb({ segments, onChange }: Props): JSX.Elem
                   overflow: undefined,
                   maxWidth: undefined,
                   transform: undefined,
-                  color: theme.colors.palette.neutral.c80,
+                  color: theme.colors.neutral.c80,
                   ":hover": {
-                    color: theme.colors.palette.neutral.c100,
+                    color: theme.colors.neutral.c100,
                     textDecoration: "underline",
                   },
                 }),

--- a/packages/react/src/components/navigation/progress/ProgressBar/Onboarding.tsx
+++ b/packages/react/src/components/navigation/progress/ProgressBar/Onboarding.tsx
@@ -17,14 +17,13 @@ const Bar = styled.div<{ on?: boolean; fill: string | number }>`
   border-top-${(p) => (p.on ? "right" : "left")}-radius: 0;
   border-bottom-${(p) => (p.on ? "right" : "left")}-radius: 0;
   flex: ${(p) => p.fill};
-  background: ${(p) =>
-    p.on ? p.theme.colors.palette.neutral.c100 : p.theme.colors.palette.neutral.c40};
+  background: ${(p) => (p.on ? p.theme.colors.neutral.c100 : p.theme.colors.neutral.c40)};
 `;
 
 const Handler = styled.div`
   transition: all 600ms linear;
   padding: 4px;
-  background: ${(p) => p.theme.colors.palette.neutral.c100};
+  background: ${(p) => p.theme.colors.neutral.c100};
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
 
   display: flex;
@@ -39,8 +38,8 @@ const Handler = styled.div`
     width: 16px;
     justify-content: center;
     align-items: center;
-    color: ${(p) => p.theme.colors.palette.neutral.c100};
-    background: ${(p) => p.theme.colors.palette.neutral.c00};
+    color: ${(p) => p.theme.colors.neutral.c100};
+    background: ${(p) => p.theme.colors.neutral.c00};
   }
 `;
 
@@ -62,15 +61,10 @@ const Onboarding = ({ steps, currentIndex }: OnboardingProps): JSX.Element => {
     <Container>
       <Bar on fill={fill} />
       <Handler key={currentStep.key}>
-        <Text className="index" color="palette.neutral.c00" fontWeight="medium" variant={"micro"}>
+        <Text className="index" color="neutral.c00" fontWeight="medium" variant={"micro"}>
           {currentIndex + 1}
         </Text>
-        <Text
-          color="palette.neutral.c00"
-          fontWeight="medium"
-          textTransform="uppercase"
-          variant={"micro"}
-        >
+        <Text color="neutral.c00" fontWeight="medium" textTransform="uppercase" variant={"micro"}>
           {currentStep.label}
         </Text>
       </Handler>

--- a/packages/react/src/components/navigation/progress/Stepper/index.tsx
+++ b/packages/react/src/components/navigation/progress/Stepper/index.tsx
@@ -62,7 +62,7 @@ export const Item = {
     ${space}
   `,
   Current: styled.div.attrs({
-    backgroundColor: "palette.primary.c90",
+    backgroundColor: "primary.c90",
   })<ColorProps>`
     width: 6px;
     height: 6px;
@@ -70,7 +70,7 @@ export const Item = {
     ${color}
   `,
   Pending: styled.div.attrs({
-    backgroundColor: "palette.neutral.c70",
+    backgroundColor: "neutral.c70",
   })<ColorProps>`
     width: ${(p) => p.theme.space[2]}px;
     height: ${(p) => p.theme.space[2]}px;
@@ -84,12 +84,12 @@ export const Item = {
 const StepText = styled(Text)<{ inactive?: boolean; errored?: boolean }>`
   color: ${(p) => {
     if (p.errored) {
-      return p.theme.colors.palette.error.c100;
+      return p.theme.colors.error.c100;
     }
     if (p.inactive) {
-      return p.theme.colors.palette.neutral.c70;
+      return p.theme.colors.neutral.c70;
     }
-    return p.theme.colors.palette.neutral.c100;
+    return p.theme.colors.neutral.c100;
   }};
 `;
 
@@ -97,7 +97,7 @@ const BaseSeparator = styled.div<{ inactive?: boolean }>`
   flex: 1;
   position: relative;
   overflow-x: hidden;
-  background-color: ${(p) => p.theme.colors.palette.neutral.c40};
+  background-color: ${(p) => p.theme.colors.neutral.c40};
   height: 1px;
   top: ${(p) => p.theme.space[5]}px;
 `;
@@ -114,25 +114,17 @@ const stepContentsByState = {
     </Item.Container>
   ),
   current: (
-    <Item.Container backgroundColor="palette.primary.c20" borderRadius="8px">
+    <Item.Container backgroundColor="primary.c20" borderRadius="8px">
       <Item.Current />
     </Item.Container>
   ),
   completed: (
-    <Item.Container
-      color="palette.primary.c90"
-      backgroundColor="palette.primary.c20"
-      borderRadius="8px"
-    >
+    <Item.Container color="primary.c90" backgroundColor="primary.c20" borderRadius="8px">
       <Item.Completed />
     </Item.Container>
   ),
   errored: (
-    <Item.Container
-      color="palette.error.c100"
-      backgroundColor="palette.warning.c30"
-      borderRadius="8px"
-    >
+    <Item.Container color="error.c100" backgroundColor="warning.c30" borderRadius="8px">
       <Item.Errored />
     </Item.Container>
   ),

--- a/packages/react/src/components/navigation/sideBar/Item/Item.tsx
+++ b/packages/react/src/components/navigation/sideBar/Item/Item.tsx
@@ -7,8 +7,8 @@ import Flex from "../../../layout/Flex";
 
 const ItemWrapper = styled.li`
   /** DEFAULT VARIANT **/
-  --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
-  --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};
+  --ll-sidebar-item-label-color: ${(props) => props.theme.colors.neutral.c80};
+  --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.neutral.c80};
   --ll-sidebar-item-background-color: unset;
 
   display: flex;
@@ -27,8 +27,8 @@ const ItemWrapper = styled.li`
 
   /** HOVER VARIANT **/
   &:hover {
-    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c100};
-    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.primary.c80};
+    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.neutral.c100};
+    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.primary.c80};
     --ll-sidebar-item-background-color: unset;
   }
 
@@ -40,15 +40,15 @@ const ItemWrapper = styled.li`
 
   /** ACTIVE VARIANT **/
   &[data-active="true"] {
-    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c100};
-    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.primary.c80};
-    --ll-sidebar-item-background-color: ${(props) => props.theme.colors.palette.primary.c20};
+    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.neutral.c100};
+    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.primary.c80};
+    --ll-sidebar-item-background-color: ${(props) => props.theme.colors.primary.c20};
   }
 
   /** DISABLE VARIANT **/
   &[data-disable="true"] {
-    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.palette.neutral.c80};
-    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.palette.neutral.c80};
+    --ll-sidebar-item-label-color: ${(props) => props.theme.colors.neutral.c80};
+    --ll-sidebar-item-icon-color: ${(props) => props.theme.colors.neutral.c80};
     --ll-sidebar-item-background-color: unset;
     opacity: 0.3;
     cursor: unset;
@@ -66,7 +66,7 @@ const DefaultBadge = styled.div`
   height: ${(p) => p.theme.space[4]}px;
   width: ${(p) => p.theme.space[4]}px;
   border-radius: ${(p) => p.theme.radii[2]}px;
-  background-color: ${(p) => p.theme.colors.palette.primary.c80};
+  background-color: ${(p) => p.theme.colors.primary.c80};
 `;
 
 export const ItemLabel = styled(Text)`

--- a/packages/react/src/components/navigation/sideBar/SideBar/SideBar.tsx
+++ b/packages/react/src/components/navigation/sideBar/SideBar/SideBar.tsx
@@ -13,9 +13,9 @@ const Nav = styled(Flex)`
   row-gap: 1.5rem;
   height: 100vh;
   max-width: 14.875rem;
-  color: ${(props) => props.theme.colors.palette.neutral.c100};
-  border-right: 1px solid ${(props) => props.theme.colors.palette.neutral.c40};
-  background-color: ${(props) => props.theme.colors.palette.background.main};
+  color: ${(props) => props.theme.colors.neutral.c100};
+  border-right: 1px solid ${(props) => props.theme.colors.neutral.c40};
+  background-color: ${(props) => props.theme.colors.background.main};
   transition: max-width 200ms;
   will-change: max-width;
 

--- a/packages/react/src/components/navigation/sideBar/Toggle/Toggle.tsx
+++ b/packages/react/src/components/navigation/sideBar/Toggle/Toggle.tsx
@@ -17,8 +17,8 @@ const ToggleButtonContainer = styled(TransitionInOut)`
   right: calc(var(--ll-side-bar-toggle-button-size) / -2);
   cursor: pointer;
 
-  background: ${(p) => p.theme.colors.palette.neutral.c20};
-  border: 1px solid ${(p) => p.theme.colors.palette.neutral.c100};
+  background: ${(p) => p.theme.colors.neutral.c20};
+  border: 1px solid ${(p) => p.theme.colors.neutral.c100};
   border-radius: 50%;
   width: var(--ll-side-bar-toggle-button-size);
   height: var(--ll-side-bar-toggle-button-size);

--- a/packages/react/src/components/tabs/Bar/index.tsx
+++ b/packages/react/src/components/tabs/Bar/index.tsx
@@ -19,7 +19,7 @@ type ItemProps = {
 
 const Bar = styled.div`
   display: inline-flex;
-  border: 1px solid ${(p) => p.theme.colors.palette.neutral.c40};
+  border: 1px solid ${(p) => p.theme.colors.neutral.c40};
   border-radius: 33px;
   padding: 2px;
 `;
@@ -32,9 +32,8 @@ const Item = styled(Flex).attrs({
   cursor: pointer;
   padding: 8px 12px 8px 12px;
   border-radius: 33px;
-  color: ${(p) =>
-    p.active ? p.theme.colors.palette.neutral.c00 : p.theme.colors.palette.neutral.c80};
-  background-color: ${(p) => (p.active ? p.theme.colors.palette.neutral.c100 : "unset")};
+  color: ${(p) => (p.active ? p.theme.colors.neutral.c00 : p.theme.colors.neutral.c80)};
+  background-color: ${(p) => (p.active ? p.theme.colors.neutral.c100 : "unset")};
 `;
 
 export default function BarTabs({ children, onTabChange, initialActiveIndex }: Props): JSX.Element {

--- a/packages/react/src/components/tabs/Pill/index.tsx
+++ b/packages/react/src/components/tabs/Pill/index.tsx
@@ -37,14 +37,14 @@ const Item = styled(Flex).attrs({ flex: 1, justifyContent: "center", alignItems:
   padding: 8px 10px 8px 10px;
   border: 1px solid;
   &[data-active="false"] {
-    color: ${(p) => p.theme.colors.palette.neutral.c80};
-    background-color: ${(p) => p.theme.colors.palette.neutral.c00};
-    border-color: ${(p) => p.theme.colors.palette.neutral.c40};
+    color: ${(p) => p.theme.colors.neutral.c80};
+    background-color: ${(p) => p.theme.colors.neutral.c00};
+    border-color: ${(p) => p.theme.colors.neutral.c40};
   }
   &[data-active="true"] {
-    color: ${(p) => p.theme.colors.palette.neutral.c00};
-    background-color: ${(p) => p.theme.colors.palette.neutral.c100};
-    border-color: ${(p) => p.theme.colors.palette.neutral.c100};
+    color: ${(p) => p.theme.colors.neutral.c00};
+    background-color: ${(p) => p.theme.colors.neutral.c100};
+    border-color: ${(p) => p.theme.colors.neutral.c100};
 
     &:not(:last-child) {
       border-right-width: 0;

--- a/packages/react/src/components/tabs/Tabs/index.tsx
+++ b/packages/react/src/components/tabs/Tabs/index.tsx
@@ -58,8 +58,7 @@ const HeaderTitle = styled(Text).attrs({
   fontWeight: "600",
 })<{ selected: boolean }>`
   margin-inline: 12px;
-  color: ${(p) =>
-    p.selected ? p.theme.colors.palette.neutral.c100 : p.theme.colors.palette.neutral.c80};
+  color: ${(p) => (p.selected ? p.theme.colors.neutral.c100 : p.theme.colors.neutral.c80)};
 `;
 
 const HeaderBottomBarFixed = styled(Flex).attrs({
@@ -68,7 +67,7 @@ const HeaderBottomBarFixed = styled(Flex).attrs({
   width: 100%;
   position: relative;
   top: 3px;
-  border-bottom: 1px solid ${(p) => p.theme.colors.palette.neutral.c40};
+  border-bottom: 1px solid ${(p) => p.theme.colors.neutral.c40};
 `;
 
 const HeaderBottomBarMoving = styled.div<HeaderBottomBarProps>`
@@ -77,13 +76,13 @@ const HeaderBottomBarMoving = styled.div<HeaderBottomBarProps>`
   width: ${(p) => p.width}px;
   transition: all 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   border-bottom: solid 3px;
-  border-bottom-color: ${(p) => p.theme.colors.palette.primary.c70};
+  border-bottom-color: ${(p) => p.theme.colors.primary.c70};
 `;
 
 const Badge = styled(Tag).attrs((p) => ({
   borderRadius: p.theme.radii[3],
-  backgroundColor: p.theme.colors.palette.primary.c70,
-  color: p.theme.colors.palette.neutral.c00,
+  backgroundColor: p.theme.colors.primary.c70,
+  color: p.theme.colors.neutral.c00,
 }))`
   padding: 5px;
   min-width: 24px;
@@ -127,10 +126,8 @@ const MainContent = styled(Flex).attrs({
   flex: 1,
 })<{ active?: boolean }>`
   width: 100%;
-  color: ${(p) =>
-    p.active ? p.theme.colors.palette.neutral.c00 : p.theme.colors.palette.neutral.c70};
-  background-color: ${(p) =>
-    p.active ? p.theme.colors.palette.neutral.c100 : p.theme.colors.palette.neutral.c00};
+  color: ${(p) => (p.active ? p.theme.colors.neutral.c00 : p.theme.colors.neutral.c70)};
+  background-color: ${(p) => (p.active ? p.theme.colors.neutral.c100 : p.theme.colors.neutral.c00)};
 `;
 
 export default function Tabs(props: Props): JSX.Element {

--- a/packages/react/src/styles/Spacing.stories.tsx
+++ b/packages/react/src/styles/Spacing.stories.tsx
@@ -19,7 +19,7 @@ const SpaceRow = styled(Flex).attrs({
   cursor: pointer;
 
   &:hover {
-    border-color: ${(props) => props.theme.colors.palette.neutral.c40};
+    border-color: ${(props) => props.theme.colors.neutral.c40};
   }
 `;
 
@@ -38,7 +38,7 @@ export const Spacing = (): JSX.Element => {
           <Text variant="small" style={{ minWidth: "5ch" }}>
             {`${value}px`}
             <br />
-            <Text variant="small" color="palette.neutral.c70">
+            <Text variant="small" color="neutral.c70">
               space[{index + 1}]
             </Text>
           </Text>
@@ -46,7 +46,7 @@ export const Spacing = (): JSX.Element => {
             flexGrow={1}
             style={{
               height: value,
-              backgroundColor: theme.colors.palette.primary.c20,
+              backgroundColor: theme.colors.primary.c20,
             }}
           />
         </SpaceRow>

--- a/packages/react/src/styles/StyleProvider.tsx
+++ b/packages/react/src/styles/StyleProvider.tsx
@@ -18,7 +18,11 @@ export const StyleProvider = ({
   const theme: Theme = useMemo(
     () => ({
       ...defaultTheme,
-      colors: { ...defaultTheme.colors, palette: palettes[selectedPalette] },
+      colors: {
+        ...defaultTheme.colors,
+        ...palettes[selectedPalette],
+        palette: palettes[selectedPalette],
+      },
       theme: selectedPalette,
     }),
     [selectedPalette],

--- a/packages/react/src/styles/global.ts
+++ b/packages/react/src/styles/global.ts
@@ -31,11 +31,11 @@ export const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
     max-height: 100%;
     width: 100vw;
     height: 100vh;
-    background-color: ${(p) => p.theme.colors.palette.neutral.c00};
+    background-color: ${(p) => p.theme.colors.neutral.c00};
   }
 
   ::selection {
-    background: ${(p) => rgba(p.theme.colors.palette.primary.c100, 0.1)};
+    background: ${(p) => rgba(p.theme.colors.primary.c100, 0.1)};
   }
 
   --track-color: rgba(0,0,0,0);

--- a/packages/react/src/styles/palettes/colors.stories.tsx
+++ b/packages/react/src/styles/palettes/colors.stories.tsx
@@ -12,7 +12,7 @@ const ColorArea = styled.div<{ type: keyof ColorPalette; shade: string }>`
   background-color: ${(p) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore next-line
-    return p.theme.colors.palette[p.type][p.shade];
+    return p.theme.colors[p.type][p.shade];
   }};
   cursor: pointer;
   border-radius: 2px;
@@ -23,7 +23,7 @@ const CardColor = ({ shade, type, value }: CardColorProps): JSX.Element => {
   const [isHovered, setIsHovered] = useState(false);
 
   const onClick = (type: string, shade: string): void => {
-    navigator.clipboard.writeText(`p.theme.colors.palette.${type}.${shade}`);
+    navigator.clipboard.writeText(`p.theme.colors.${type}.${shade}`);
   };
 
   return (

--- a/packages/react/src/styles/theme.ts
+++ b/packages/react/src/styles/theme.ts
@@ -177,7 +177,7 @@ const overflow = {
     overflow-x: scroll;
     will-change: transform;
     &:hover {
-      --track-color: ${(p) => p.theme.colors.palette.neutral.c30};
+      --track-color: ${(p) => p.theme.colors.neutral.c30};
     }
   `,
   y: css`
@@ -185,7 +185,7 @@ const overflow = {
     overflow-y: scroll;
     will-change: transform;
     &:hover {
-      --track-color: ${(p) => p.theme.colors.palette.neutral.c30};
+      --track-color: ${(p) => p.theme.colors.neutral.c30};
     }
   `,
   yAuto: css`
@@ -193,14 +193,14 @@ const overflow = {
     overflow-y: auto;
     will-change: transform;
     &:hover {
-      --track-color: ${(p) => p.theme.colors.palette.neutral.c30};
+      --track-color: ${(p) => p.theme.colors.neutral.c30};
     }
   `,
   xy: css`
     overflow: scroll;
     will-change: transform;
     &:hover {
-      --track-color: ${(p) => p.theme.colors.palette.neutral.c30};
+      --track-color: ${(p) => p.theme.colors.neutral.c30};
     }
   `,
   trackSize: 12,
@@ -245,7 +245,10 @@ declare module "styled-components" {
     fontSizes: number[];
     space: number[];
     shadows: string[];
-    colors: {
+    colors: ColorPalette & {
+      /**
+       * @deprecated Do not use the .palette prefix anymore!
+       */
       palette: ColorPalette;
     };
     fontWeights: Record<string, string>;
@@ -287,6 +290,7 @@ const theme: DefaultTheme = {
   shadows,
   colors: {
     palette: palettes.light,
+    ...palettes.light,
   },
   animations,
   overflow,


### PR DESCRIPTION
#### Spreads the palette colors inside the `.colors` theme object

*The `.palette` prefix is still useable for now but marked as deprecated.*