### PR TITLE
Improve Checkbox/Flex

### DIFF
--- a/packages/native/src/components/Form/Checkbox/index.tsx
+++ b/packages/native/src/components/Form/Checkbox/index.tsx
@@ -5,11 +5,13 @@ import Text from "../../Text";
 import Flex from "../../Layout/Flex";
 import CheckAlone from "@ledgerhq/icons-ui/native/CheckAloneMedium";
 
+import type { BaseTextProps } from "../../Text";
+
 type CheckboxProps = {
   checked: boolean;
   onChange?: () => void;
   disabled?: boolean;
-  label?: string;
+  label?: BaseTextProps["children"];
 };
 
 const Square = styled(Flex).attrs({

--- a/packages/native/src/components/Layout/Flex/index.tsx
+++ b/packages/native/src/components/Layout/Flex/index.tsx
@@ -11,6 +11,7 @@ import {
   LayoutProps,
   space,
   SpaceProps,
+  border,
 } from "styled-system";
 
 // Nb Expose style props as you need them instead of allowing for all to be passed directly.
@@ -42,6 +43,7 @@ const FlexBox = styled.View<Props>`
   ${background};
   ${color};
   ${layout};
+  ${border};
 `;
 
 export default FlexBox;

--- a/packages/native/src/styles/theme.ts
+++ b/packages/native/src/styles/theme.ts
@@ -1,5 +1,6 @@
 import { ColorPalette, palettes } from "@ledgerhq/ui-shared";
 
+//                    0  1  2  3  4   5   6   7   8   9   10  11  12  13  14
 export const space = [0, 2, 4, 8, 12, 14, 16, 24, 32, 40, 48, 64, 80, 96, 120];
 
 export type TextVariants =
@@ -19,6 +20,7 @@ export type TextVariants =
 export type ThemeScale<Type, Aliases extends string> = Array<Type> &
   Record<Aliases, Type>;
 
+//                        0   1   2   3   4   5   6   7   8
 export const fontSizes = [10, 11, 12, 13, 14, 16, 18, 24, 28] as ThemeScale<
   number,
   TextVariants


### PR DESCRIPTION
This first commit isn't breaking change because `string` type is part of the `ReactNode` type

If #105 is merged before that one, the second commit of this PR has to be removed (b03adcc77fd94937225b733abf3ece4806ee41e8)