### PR TITLE
React - BoxedIcon component

### DIFF
--- a/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
@@ -47,10 +47,10 @@ const Story = {
         "[Not a BoxedIcon prop, only for this Storybook example] - Controls whether a `Badge` prop is passed to the `BoxedIcon` component.",
     },
     Badge: {
-      control: { options: [], type: "select" },
+      control: false,
     },
     Icon: {
-      control: { options: [], type: "select" },
+      control: false,
     },
     iconColor: {
       type: "string",

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Icon, { iconNames } from "./Icon";
 import BoxedIconC, {
-  BadgeProps,
   BoxedIconProps,
   IconProps,
   DEFAULT_BOX_SIZE,
@@ -10,10 +9,6 @@ import BoxedIconC, {
 } from "./BoxedIcon";
 
 const ExampleIcon = ({ size, color, name }: IconProps & { name: string }) => (
-  <Icon name={name} {...{ size, color }} />
-);
-
-const ExampleBadge = ({ size, color, name }: BadgeProps & { name: string }) => (
   <Icon name={name} {...{ size, color }} />
 );
 
@@ -102,17 +97,15 @@ const BoxedIconTemplate = (
   const iconColor = args.iconColor;
   const IconComp =
     args.Icon || ((props: IconProps) => <ExampleIcon {...props} name={args.exampleIconName} />);
-  const BadgeComp = !args.exampleBadgeEnabled
-    ? undefined
-    : args.Badge ||
-      ((props: BadgeProps) => <ExampleBadge {...props} name={args.exampleBadgeName} />);
+  const BadgeComp =
+    args.Badge || ((props: IconProps) => <ExampleIcon {...props} name={args.exampleBadgeName} />);
   const iconSize = args.iconSize;
   const size = args.size;
 
   return (
     <BoxedIconC
       Icon={IconComp}
-      {...(args.exampleBadgeEnabled ? { Badge: BadgeComp } : {})}
+      Badge={args.exampleBadgeEnabled ? BadgeComp : undefined}
       badgeColor={badgeColor}
       badgeSize={badgeSize}
       borderColor={borderColor}

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
@@ -25,7 +25,7 @@ const Story = {
       type: "enum",
       defaultValue: "Activity",
       description:
-        "[Not a BoxedIcon prop, only for StoryBook example], Icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Icon` prop",
+        "[Not a BoxedIcon prop, only for this Storybook example] - Icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Icon` prop.",
       control: {
         options: iconNames,
         control: {
@@ -37,13 +37,19 @@ const Story = {
       type: "enum",
       defaultValue: "CircledCheckSolid",
       description:
-        "[Not a BoxedIcon prop, only for StoryBook example], Badge icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Badge` prop",
+        "[Not a BoxedIcon prop, only for this Storybook example] - Badge icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Badge` prop.",
       control: {
         options: iconNames,
         control: {
           type: "select",
         },
       },
+    },
+    exampleBadgeEnabled: {
+      type: "boolean",
+      defaultValue: true,
+      description:
+        "[Not a BoxedIcon prop, only for this Storybook example] - Controls whether a `Badge` prop is passed to the `BoxedIcon` component.",
     },
     Badge: {
       control: { options: [], type: "select" },
@@ -84,7 +90,11 @@ const Story = {
 export default Story;
 
 const BoxedIconTemplate = (
-  args: BoxedIconProps & { exampleIconName: string; exampleBadgeName: string },
+  args: BoxedIconProps & {
+    exampleIconName: string;
+    exampleBadgeName: string;
+    exampleBadgeEnabled: boolean;
+  },
 ) => {
   const badgeColor = args.badgeColor;
   const badgeSize = args.badgeSize;
@@ -92,15 +102,17 @@ const BoxedIconTemplate = (
   const iconColor = args.iconColor;
   const IconComp =
     args.Icon || ((props: IconProps) => <ExampleIcon {...props} name={args.exampleIconName} />);
-  const BadgeComp =
-    args.Badge || ((props: BadgeProps) => <ExampleBadge {...props} name={args.exampleBadgeName} />);
+  const BadgeComp = !args.exampleBadgeEnabled
+    ? undefined
+    : args.Badge ||
+      ((props: BadgeProps) => <ExampleBadge {...props} name={args.exampleBadgeName} />);
   const iconSize = args.iconSize;
   const size = args.size;
 
   return (
     <BoxedIconC
       Icon={IconComp}
-      Badge={BadgeComp}
+      {...(args.exampleBadgeEnabled ? { Badge: BadgeComp } : {})}
       badgeColor={badgeColor}
       badgeSize={badgeSize}
       borderColor={borderColor}

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.stories.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import Icon, { iconNames } from "./Icon";
+import BoxedIconC, {
+  BadgeProps,
+  BoxedIconProps,
+  IconProps,
+  DEFAULT_BOX_SIZE,
+  DEFAULT_ICON_SIZE,
+  DEFAULT_BADGE_SIZE,
+} from "./BoxedIcon";
+
+const ExampleIcon = ({ size, color, name }: IconProps & { name: string }) => (
+  <Icon name={name} {...{ size, color }} />
+);
+
+const ExampleBadge = ({ size, color, name }: BadgeProps & { name: string }) => (
+  <Icon name={name} {...{ size, color }} />
+);
+
+const Story = {
+  title: "Asorted/Icons/BoxedIcon",
+  component: BoxedIconC,
+  argTypes: {
+    exampleIconName: {
+      type: "enum",
+      defaultValue: "Activity",
+      description:
+        "[Not a BoxedIcon prop, only for StoryBook example], Icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Icon` prop",
+      control: {
+        options: iconNames,
+        control: {
+          type: "select",
+        },
+      },
+    },
+    exampleBadgeName: {
+      type: "enum",
+      defaultValue: "CircledCheckSolid",
+      description:
+        "[Not a BoxedIcon prop, only for StoryBook example], Badge icon name. Value is passed to the `Icon` component of this UI library which is then used for the `Badge` prop",
+      control: {
+        options: iconNames,
+        control: {
+          type: "select",
+        },
+      },
+    },
+    Badge: {
+      control: { options: [], type: "select" },
+    },
+    Icon: {
+      control: { options: [], type: "select" },
+    },
+    iconColor: {
+      type: "string",
+      defaultValue: "hsla(110, 50%, 57%, 1)",
+      control: { control: "color" },
+    },
+    badgeColor: {
+      type: "string",
+      defaultValue: "hsla(110, 50%, 57%, 1)",
+      control: { control: "color" },
+    },
+    borderColor: {
+      type: "string",
+      defaultValue: "success.c40",
+      control: { control: "color" },
+    },
+    iconSize: {
+      type: "number",
+      defaultValue: DEFAULT_ICON_SIZE,
+    },
+    badgeSize: {
+      type: "number",
+      defaultValue: DEFAULT_BADGE_SIZE,
+    },
+    size: {
+      type: "number",
+      defaultValue: DEFAULT_BOX_SIZE,
+    },
+  },
+};
+
+export default Story;
+
+const BoxedIconTemplate = (
+  args: BoxedIconProps & { exampleIconName: string; exampleBadgeName: string },
+) => {
+  const badgeColor = args.badgeColor;
+  const badgeSize = args.badgeSize;
+  const borderColor = args.borderColor;
+  const iconColor = args.iconColor;
+  const IconComp =
+    args.Icon || ((props: IconProps) => <ExampleIcon {...props} name={args.exampleIconName} />);
+  const BadgeComp =
+    args.Badge || ((props: BadgeProps) => <ExampleBadge {...props} name={args.exampleBadgeName} />);
+  const iconSize = args.iconSize;
+  const size = args.size;
+
+  return (
+    <BoxedIconC
+      Icon={IconComp}
+      Badge={BadgeComp}
+      badgeColor={badgeColor}
+      badgeSize={badgeSize}
+      borderColor={borderColor}
+      iconColor={iconColor}
+      iconSize={iconSize}
+      size={size}
+    />
+  );
+};
+
+export const BoxedIcon = BoxedIconTemplate.bind({});

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
@@ -54,11 +54,11 @@ export type IconBoxProps = {
   /**
    * Color of the border
    */
-  borderColor: string;
+  borderColor?: string;
   /**
    * Badge color, will be applied to the component provided in the `Badge` prop
    */
-  badgeColor: string;
+  badgeColor?: string;
   /**
    * Badge size, will be applied to the component provided in the `Badge` prop
    */

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
@@ -50,7 +50,7 @@ export type IconBoxProps = {
   /**
    * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `badgeSize` or a default size.
    */
-  Badge: React.ComponentType<BadgeProps> | ((props: BadgeProps) => JSX.Element);
+  Badge?: React.ComponentType<BadgeProps> | ((props: BadgeProps) => JSX.Element);
   /**
    * Color of the border
    */

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import styled from "styled-components";
+import Flex from "../../layout/Flex";
+
+export const DEFAULT_BOX_SIZE = 40;
+export const DEFAULT_ICON_SIZE = 16;
+export const DEFAULT_BADGE_SIZE = 20;
+
+const getTopRightSquareClippedPolygon = (boxSize: number, rectangleSize: number) => {
+  // clipping path that hides top right square of size{rectangleSize}px
+  const diff = boxSize - rectangleSize;
+  return `polygon(0 0, 0 0, 0 0, ${diff}px 0, ${diff}px ${rectangleSize}px, 100% ${rectangleSize}px, 100% 100%, 100% 100%, 100% 100%, 0 100%, 0 100%, 0 100%)`;
+};
+
+const Container = styled(Flex).attrs((p: { size: number }) => ({
+  heigth: p.size,
+  width: p.size,
+  alignItems: "center",
+  justifyContent: "center",
+  position: "relative",
+}))<{ size: number }>``;
+
+const IconBoxBackground = styled(Flex)<{ size: number; hasBadge: boolean }>`
+  position: absolute;
+  height: ${(p) => p.size}px;
+  width: ${(p) => p.size}px;
+  ${(p) => {
+    return p.hasBadge && `clip-path: ${getTopRightSquareClippedPolygon(p.size, 15)};`;
+  }};
+  border-radius: ${(p) => p.theme.radii[2]}px;
+`;
+
+const BadgeContainer = styled.div<{ badgeSize: number }>`
+  position: absolute;
+  ${(p) => `
+    top: -${p.badgeSize / 2 - 2}px;
+    right: -${p.badgeSize / 2 - 2}px;`}
+`;
+
+export type BadgeProps = {
+  size?: number;
+  color?: string;
+};
+export type IconProps = {
+  size?: number;
+  color?: string;
+};
+
+export type IconBoxProps = {
+  /**
+   * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `badgeSize` or a default size.
+   */
+  Badge: React.ComponentType<BadgeProps> | ((props: BadgeProps) => JSX.Element);
+  /**
+   * Color of the border
+   */
+  borderColor: string;
+  /**
+   * Badge color, will be applied to the component provided in the `Badge` prop
+   */
+  badgeColor: string;
+  /**
+   * Badge size, will be applied to the component provided in the `Badge` prop
+   */
+  badgeSize?: number;
+  children?: JSX.Element;
+  /**
+   * Box size for preview
+   */
+  size?: number;
+};
+
+export type BoxedIconProps = IconBoxProps & {
+  /**
+   * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `iconSize` or a default size.
+   */
+  Icon: React.ComponentType<IconProps> | ((props: IconProps) => JSX.Element);
+  /**
+   * Icon size, will be applied to the component provided in the `Icon` prop
+   */
+  iconSize?: number;
+  /**
+   * Icon color, will be applied to the component provided in the `Icon` prop
+   */
+  iconColor?: string;
+};
+
+export const IconBox = ({
+  Badge,
+  size = DEFAULT_BOX_SIZE,
+  children,
+  borderColor = "neutral.c40",
+  badgeColor,
+  badgeSize = DEFAULT_BADGE_SIZE,
+}: IconBoxProps) => {
+  const hasBadge = !!Badge;
+  return (
+    <Container size={size}>
+      <IconBoxBackground
+        size={size}
+        hasBadge={hasBadge}
+        border="1px solid"
+        borderColor={borderColor}
+      />
+      {children}
+      {hasBadge && (
+        <BadgeContainer badgeSize={badgeSize}>
+          <Badge size={badgeSize} color={badgeColor} />
+        </BadgeContainer>
+      )}
+    </Container>
+  );
+};
+
+const BoxedIcon = ({
+  Icon,
+  iconSize = DEFAULT_ICON_SIZE,
+  iconColor,
+  ...iconBoxProps
+}: BoxedIconProps) => {
+  return (
+    <IconBox {...iconBoxProps}>
+      <Icon size={iconSize || DEFAULT_ICON_SIZE} color={iconColor} />
+    </IconBox>
+  );
+};
+
+export default BoxedIcon;

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
@@ -7,7 +7,7 @@ export const DEFAULT_ICON_SIZE = 16;
 export const DEFAULT_BADGE_SIZE = 20;
 
 const getTopRightSquareClippedPolygon = (boxSize: number, rectangleSize: number) => {
-  // clipping path that hides top right square of size{rectangleSize}px
+  // clipping path that hides top right square of size `${rectangleSize}px`
   const diff = boxSize - rectangleSize;
   return `polygon(0 0, 0 0, 0 0, ${diff}px 0, ${diff}px ${rectangleSize}px, 100% ${rectangleSize}px, 100% 100%, 100% 100%, 100% 100%, 0 100%, 0 100%, 0 100%)`;
 };
@@ -37,10 +37,6 @@ const BadgeContainer = styled.div<{ badgeSize: number }>`
     right: -${p.badgeSize / 2 - 2}px;`}
 `;
 
-export type BadgeProps = {
-  size?: number;
-  color?: string;
-};
 export type IconProps = {
   size?: number;
   color?: string;
@@ -50,7 +46,7 @@ export type IconBoxProps = {
   /**
    * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `badgeSize` or a default size.
    */
-  Badge?: React.ComponentType<BadgeProps> | ((props: BadgeProps) => JSX.Element);
+  Badge?: React.ComponentType<IconProps> | ((props: IconProps) => JSX.Element);
   /**
    * Color of the border
    */

--- a/packages/react/src/components/asorted/Icon/Icon.tsx
+++ b/packages/react/src/components/asorted/Icon/Icon.tsx
@@ -1,6 +1,5 @@
 import * as icons from "@ledgerhq/icons-ui/react";
 import React from "react";
-import styled from "styled-components";
 
 export type Props = {
   name: string;
@@ -33,12 +32,5 @@ const Icon = ({
   }
   return null;
 };
-
-export const IconBox = styled.div`
-  padding: ${(p) => p.theme.space[6]}px;
-  border: 1px solid ${(p) => p.theme.colors.neutral.c40};
-  border-radius: ${(p) => p.theme.radii[2]}px;
-  display: inline-flex;
-`;
 
 export default Icon;

--- a/packages/react/src/components/asorted/Icon/Icons.stories.tsx
+++ b/packages/react/src/components/asorted/Icon/Icons.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import Icon, { iconNames, Props as IconProps, IconBox } from "./Icon";
+import Icon, { iconNames, Props as IconProps } from "./Icon";
 import { useTheme } from "styled-components";
 import { Text, SearchInput, Flex, Grid } from "../../..";
 
@@ -133,17 +133,5 @@ const IconTemplate = (args: IconProps) => {
   return <Icon {...args} color={color} />;
 };
 
-const BoxedIconTemplate = (args: IconProps) => {
-  const theme = useTheme();
-  const color = args.color || theme.colors.neutral.c100;
-
-  return (
-    <IconBox>
-      <Icon {...args} color={color} />
-    </IconBox>
-  );
-};
-
 export const List = ListTemplate.bind({});
 export const SingleIcon = IconTemplate.bind({});
-export const BoxedIcon = BoxedIconTemplate.bind({});

--- a/packages/react/src/components/asorted/Icon/index.tsx
+++ b/packages/react/src/components/asorted/Icon/index.tsx
@@ -1,2 +1,4 @@
-export { default, iconNames, IconBox } from "./Icon";
+export { default, iconNames } from "./Icon";
+import BoxedIcon, { IconBox } from "./BoxedIcon";
+export { BoxedIcon, IconBox };
 export type { Props } from "./Icon";

--- a/packages/react/src/components/styled.ts
+++ b/packages/react/src/components/styled.ts
@@ -14,6 +14,8 @@ import {
   LayoutProps,
   overflow,
   OverflowProps,
+  border,
+  BorderProps,
 } from "styled-system";
 
 export type BaseStyledProps = SpaceProps &
@@ -21,6 +23,7 @@ export type BaseStyledProps = SpaceProps &
   PositionProps &
   ColorProps &
   LayoutProps &
+  BorderProps &
   OverflowProps & {
     /**
      * The columnGap CSS property sets the size of the gap (gutter) between an element's grid columns.
@@ -41,6 +44,7 @@ export const baseStyles: InterpolationFunction<unknown> = compose(
   layout,
   overflow,
   gaps,
+  border,
 );
 
 const proxyStyled = new Proxy(styled, {


### PR DESCRIPTION
Component that wraps an `Icon` component (passed as props) in a styled box with an optional `Badge` component (passed as props).

In storybook -> Asorted/Icons/BoxedIcon 

[Figma for reference](https://www.figma.com/file/WXCEmRMwW47ELrFonzPTGg/LLD-%2F-Library?node-id=5136%3A32649)

<img width="716" alt="Screenshot 2021-11-29 at 15 04 23" src="https://user-images.githubusercontent.com/91890529/143881937-d7b41007-5140-4fb1-a6b3-19efac338e7e.png">


