### PR TITLE
React - Alert & Link enhancements

### DIFF
--- a/packages/react/src/components/cta/Link/Link.stories.tsx
+++ b/packages/react/src/components/cta/Link/Link.stories.tsx
@@ -8,7 +8,7 @@ export default {
   parameters: { actions: { argTypesRegex: false } },
   argTypes: {
     Icon: {
-      options: [],
+      control: false,
     },
     type: {
       options: ["main", "shade", "color", undefined],

--- a/packages/react/src/components/cta/Link/Link.stories.tsx
+++ b/packages/react/src/components/cta/Link/Link.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Link, { LinkProps } from "./index";
+import Link, { LinkProps, DEFAULT_ICON_POSITION, DEFAULT_SIZE, DEFAULT_TYPE } from "./index";
 import { PlusMedium } from "@ledgerhq/icons-ui/react";
 
 export default {
@@ -7,14 +7,19 @@ export default {
   component: Link,
   parameters: { actions: { argTypesRegex: false } },
   argTypes: {
+    Icon: {
+      options: [],
+    },
     type: {
-      options: ["main", "shade", "color"],
+      options: ["main", "shade", "color", undefined],
+      defaultValue: DEFAULT_TYPE,
       control: {
         type: "radio",
       },
     },
     size: {
-      options: ["small", "medium", "large"],
+      options: ["small", "medium", "large", undefined],
+      defaultValue: DEFAULT_SIZE,
       control: {
         type: "radio",
       },
@@ -23,12 +28,18 @@ export default {
       type: "text",
     },
     iconPosition: {
-      options: ["right", "left"],
-      control: {
-        type: "radio",
-      },
+      defaultValue: DEFAULT_ICON_POSITION,
+      options: ["left", "right", undefined],
     },
+    textProps: {},
     disabled: {
+      type: "boolean",
+    },
+    color: {
+      type: "string",
+      control: { control: "color" },
+    },
+    alwaysUnderline: {
       type: "boolean",
     },
   },

--- a/packages/react/src/components/cta/Link/index.tsx
+++ b/packages/react/src/components/cta/Link/index.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { getLinkColors } from "./getLinkStyle";
 import { ctaIconSize, ctaTextType } from "../getCtaStyle";
 import { Text } from "../../asorted";
+import { TextProps } from "../../asorted/Text";
 import baseStyled, { BaseStyledProps } from "../../styled";
 
 export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
@@ -10,6 +11,9 @@ export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
     Icon?: React.ComponentType<{ size: number; color?: string }>;
     type?: "main" | "shade" | "color";
     size?: "small" | "medium" | "large";
+    color?: string;
+    textProps?: TextProps;
+    alwaysUnderline?: boolean;
     iconPosition?: "right" | "left";
     disabled?: boolean;
     children?: React.ReactNode;
@@ -27,8 +31,8 @@ const IconContainer = styled.div<{
 `;
 
 export const Base = baseStyled.a<LinkProps>`
-  color: ${({ theme, disabled, type = "main" }) =>
-    getLinkColors(theme.colors)[disabled ? "disabled" : type]["default"]};
+  color: ${({ color, theme, disabled, type = "main" }) =>
+    color || getLinkColors(theme.colors)[disabled ? "disabled" : type]["default"]};
   cursor: pointer;
   display: inline-flex;
   flex-direction: row;
@@ -36,44 +40,50 @@ export const Base = baseStyled.a<LinkProps>`
   align-items: center;
   justify-content: center;
 
-  text-decoration: none;
-
   :hover {
     text-decoration: underline;
   }
   :active {
-    color: ${({ theme, type = "main" }) => getLinkColors(theme.colors)[type]["pressed"]};
+    color: ${({ color, theme, type = "main" }) =>
+      color || getLinkColors(theme.colors)[type]["pressed"]};
     text-decoration: underline;
   }
+
+  text-decoration: ${(p) => (p.alwaysUnderline ? "underline" : "none")};
+
 `;
 
 const LinkContainer = (props: LinkProps): React.ReactElement => {
-  const { Icon, iconPosition = "right", children, size = "medium" } = props;
+  const { Icon, iconPosition = "right", children, color, size = "medium", textProps } = props;
+
+  const text = (
+    <Text
+      variant={ctaTextType[size]}
+      fontWeight="semiBold"
+      color={color || "inherit"}
+      {...textProps}
+    >
+      {children}
+    </Text>
+  );
+
   return (
     <>
-      {iconPosition === "right" && children ? (
-        <Text variant={ctaTextType[size]} fontWeight="semiBold" color={"inherit"}>
-          {children}
-        </Text>
-      ) : null}
+      {iconPosition === "right" && children ? text : null}
       {Icon ? (
         <IconContainer iconLink={!children} iconPosition={iconPosition}>
-          <Icon size={ctaIconSize[size]} color={"currentcolor"} />
+          <Icon size={ctaIconSize[size]} color={color || "currentcolor"} />
         </IconContainer>
       ) : null}
-      {iconPosition === "left" && children ? (
-        <Text variant={ctaTextType[size]} fontWeight="semiBold" color={"inherit"}>
-          {children}
-        </Text>
-      ) : null}
+      {iconPosition === "left" && children ? text : null}
     </>
   );
 };
 
 const Link = (props: LinkProps): React.ReactElement => {
-  const { type = "main", size = "medium" } = props;
+  const { type = "main", size = "medium", color } = props;
   return (
-    <Base {...props}>
+    <Base color={color} {...props}>
       <LinkContainer {...props} type={type} size={size} />
     </Base>
   );

--- a/packages/react/src/components/cta/Link/index.tsx
+++ b/packages/react/src/components/cta/Link/index.tsx
@@ -8,16 +8,41 @@ import baseStyled, { BaseStyledProps } from "../../styled";
 
 export type LinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
   BaseStyledProps & {
+    /**
+     * Component that takes `{size: number; color?: string}` as props
+     */
     Icon?: React.ComponentType<{ size: number; color?: string }>;
+    /**
+     * Affects the colors of the text, icon & underline, can be overriden by the `color` prop
+     */
     type?: "main" | "shade" | "color";
+    /**
+     * Affect the font variant & icon size
+     */
     size?: "small" | "medium" | "large";
+    /**
+     * Color of the link, overrides colors defined by the `type` prop
+     */
     color?: string;
+    /**
+     * Props passed to the rendered text
+     */
     textProps?: TextProps;
+    /**
+     * If true text will always be underlined, else it will be underlined only on hover
+     */
     alwaysUnderline?: boolean;
+    /**
+     * Position of the icon relative to the text
+     */
     iconPosition?: "right" | "left";
     disabled?: boolean;
     children?: React.ReactNode;
   };
+
+export const DEFAULT_ICON_POSITION = "right";
+export const DEFAULT_SIZE = "medium";
+export const DEFAULT_TYPE = "main";
 
 const IconContainer = styled.div<{
   iconPosition: "right" | "left";
@@ -53,9 +78,14 @@ export const Base = baseStyled.a<LinkProps>`
 
 `;
 
-const LinkContainer = (props: LinkProps): React.ReactElement => {
-  const { Icon, iconPosition = "right", children, color, size = "medium", textProps } = props;
-
+const LinkContainer = ({
+  Icon,
+  iconPosition = DEFAULT_ICON_POSITION,
+  children,
+  color,
+  size = DEFAULT_SIZE,
+  textProps,
+}: LinkProps): React.ReactElement => {
   const text = (
     <Text
       variant={ctaTextType[size]}
@@ -81,7 +111,7 @@ const LinkContainer = (props: LinkProps): React.ReactElement => {
 };
 
 const Link = (props: LinkProps): React.ReactElement => {
-  const { type = "main", size = "medium", color } = props;
+  const { type = DEFAULT_TYPE, size = DEFAULT_SIZE, color } = props;
   return (
     <Base color={color} {...props}>
       <LinkContainer {...props} type={type} size={size} />

--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -5,6 +5,7 @@ import Text from "../../asorted/Text";
 import { Icons } from "../../../../src/assets";
 export default {
   title: "Messages/Alerts",
+  component: Alert,
   argTypes: {
     type: {
       options: ["info", "warning", "error"],
@@ -25,7 +26,6 @@ export default {
       defaultValue: true,
     },
   },
-  component: Alert,
 };
 
 export const Default = (args: AlertProps): JSX.Element => {
@@ -39,7 +39,8 @@ export const WithContent = (args: AlertProps) => {
       renderContent={({ color, textProps }) => (
         <>
           <Text color="inherit" {...textProps}>
-            Some additional text that might overflow to the right but doesn't
+            Your xpub is privacy-sensitive data. Use with caution, especially when disclosing to
+            third parties.
           </Text>
           <Link
             color={color}

--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -25,6 +25,7 @@ export default {
       defaultValue: true,
     },
   },
+  component: Alert,
 };
 
 export const Default = (args: AlertProps): JSX.Element => {
@@ -35,17 +36,14 @@ export const WithChildren = (args: AlertProps) => {
   return (
     <Alert
       {...args}
-      renderContent={({ color }) => (
+      renderContent={({ color, textProps }) => (
         <>
-          <Text color="inherit" variant="paragraph" fontWeight="medium">
-            Some children text
+          <Text color="inherit" {...textProps}>
+            Some additional text that might overflow to the right but doesn't
           </Text>
           <Link
             color={color}
-            textProps={{
-              variant: "paragraph",
-              fontWeight: "medium",
-            }}
+            textProps={textProps}
             alwaysUnderline
             size="small"
             Icon={Icons.ExternalLinkMedium}

--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import Alert, { AlertProps } from "./index";
+import Link from "../../cta/Link";
+import Text from "../../asorted/Text";
+import { Icons } from "../../../../src/assets";
 export default {
   title: "Messages/Alerts",
   argTypes: {
@@ -13,7 +16,7 @@ export default {
       control: {
         type: "text",
       },
-      defaultValue: "Label",
+      defaultValue: "Title",
     },
     showIcon: {
       control: {
@@ -26,4 +29,31 @@ export default {
 
 export const Default = (args: AlertProps): JSX.Element => {
   return <Alert {...args} />;
+};
+
+export const WithChildren = (args: AlertProps) => {
+  return (
+    <Alert
+      {...args}
+      renderContent={({ color }) => (
+        <>
+          <Text color="inherit" variant="paragraph" fontWeight="medium">
+            Some children text
+          </Text>
+          <Link
+            color={color}
+            textProps={{
+              variant: "paragraph",
+              fontWeight: "medium",
+            }}
+            alwaysUnderline
+            size="small"
+            Icon={Icons.ExternalLinkMedium}
+          >
+            And a learn more link
+          </Link>
+        </>
+      )}
+    />
+  );
 };

--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -32,7 +32,7 @@ export const Default = (args: AlertProps): JSX.Element => {
   return <Alert {...args} />;
 };
 
-export const WithChildren = (args: AlertProps) => {
+export const WithContent = (args: AlertProps) => {
   return (
     <Alert
       {...args}

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { css, useTheme } from "styled-components";
+import styled, { useTheme } from "styled-components";
 import Text from "../../asorted/Text";
 import { TextVariants } from "../../../styles/theme";
 import Flex from "../../layout/Flex";
@@ -64,19 +64,10 @@ const getColors = ({ theme, type }: { theme: DefaultTheme; type?: AlertType }) =
   }
 };
 
-const StyledAlertContainer = styled.div<{ type?: AlertType }>`
-  ${(p) => {
-    const { background, color } = getColors({ theme: p.theme, type: p.type });
-    return css`
-      background: ${background};
-      color: ${color};
-    `;
-  }}
-  overflow-wrap: break-all;
-
+const StyledAlertContainer = styled(Flex).attrs(() => ({
+  padding: 6,
+}))<{ background?: string; color?: string }>`
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
-  padding: 16px;
-  display: flex;
   align-items: center;
 `;
 
@@ -87,13 +78,13 @@ export default function Alert({
   renderContent,
 }: AlertProps): JSX.Element {
   const theme = useTheme();
-  const { color } = getColors({ theme, type });
+  const { color, background } = getColors({ theme, type });
   const textProps: { variant?: TextVariants; fontWeight?: string } = {
     variant: "paragraph",
     fontWeight: "medium",
   };
   return (
-    <StyledAlertContainer type={type}>
+    <StyledAlertContainer color={color} backgroundColor={background}>
       {showIcon && !!icons[type] && <StyledIconContainer>{icons[type]}</StyledIconContainer>}
       <Flex flexDirection="column" alignItems="flex-start" rowGap="6px">
         {title && (

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled, { css, useTheme } from "styled-components";
 import Text from "../../asorted/Text";
+import { TextVariants } from "../../../styles/theme";
 import Flex from "../../layout/Flex";
 import ShieldSecurityMedium from "@ledgerhq/icons-ui/react/ShieldSecurityMedium";
 import CircledCrossMedium from "@ledgerhq/icons-ui/react/CircledCrossMedium";
@@ -8,11 +9,25 @@ import CircledAlertMedium from "@ledgerhq/icons-ui/react/CircledAlertMedium";
 import { DefaultTheme } from "styled-components/native";
 
 type AlertType = "info" | "warning" | "error";
-
 export interface AlertProps {
+  /**
+   * Affects the colors of the background & text and what icon can be displayed
+   */
   type?: AlertType;
+  /**
+   * Title of the Alert
+   */
   title?: string;
-  renderContent?: (props: { color: string }) => JSX.Element;
+  /**
+   * Method for rendering additional content under the title `{ color: string; textProps: { variant?: TextVariants; fontWeight?: string } }` is passed as props to easily style text elements
+   */
+  renderContent?: (props: {
+    color: string;
+    textProps: { variant?: TextVariants; fontWeight?: string };
+  }) => JSX.Element;
+  /**
+   * Whether or not to display an icon
+   */
   showIcon?: boolean;
 }
 
@@ -57,16 +72,12 @@ const StyledAlertContainer = styled.div<{ type?: AlertType }>`
       color: ${color};
     `;
   }}
-  word-break: break-all;
+  overflow-wrap: break-all;
 
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
   padding: 16px;
   display: flex;
   align-items: center;
-`;
-
-const ContentContainer = styled(Flex)`
-  flex-direction: column;
 `;
 
 export default function Alert({
@@ -77,17 +88,21 @@ export default function Alert({
 }: AlertProps): JSX.Element {
   const theme = useTheme();
   const { color } = getColors({ theme, type });
+  const textProps: { variant?: TextVariants; fontWeight?: string } = {
+    variant: "paragraph",
+    fontWeight: "medium",
+  };
   return (
     <StyledAlertContainer type={type}>
       {showIcon && !!icons[type] && <StyledIconContainer>{icons[type]}</StyledIconContainer>}
-      <ContentContainer rowGap="6px">
+      <Flex flexDirection="column" alignItems="flex-start" rowGap="6px">
         {title && (
-          <Text variant="paragraph" fontWeight="medium" color="inherit">
+          <Text {...textProps} color="inherit">
             {title}
           </Text>
         )}
-        {renderContent && renderContent({ color })}
-      </ContentContainer>
+        {renderContent && renderContent({ color, textProps })}
+      </Flex>
     </StyledAlertContainer>
   );
 }

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -1,15 +1,18 @@
 import React from "react";
-import styled, { css } from "styled-components";
+import styled, { css, useTheme } from "styled-components";
 import Text from "../../asorted/Text";
+import Flex from "../../layout/Flex";
 import ShieldSecurityMedium from "@ledgerhq/icons-ui/react/ShieldSecurityMedium";
 import CircledCrossMedium from "@ledgerhq/icons-ui/react/CircledCrossMedium";
 import CircledAlertMedium from "@ledgerhq/icons-ui/react/CircledAlertMedium";
+import { DefaultTheme } from "styled-components/native";
 
 type AlertType = "info" | "warning" | "error";
 
 export interface AlertProps {
   type?: AlertType;
-  title: string;
+  title?: string;
+  renderContent?: (props: { color: string }) => JSX.Element;
   showIcon?: boolean;
 }
 
@@ -25,27 +28,36 @@ const icons = {
   error: <CircledCrossMedium size={20} />,
 };
 
+const getColors = ({ theme, type }: { theme: DefaultTheme; type?: AlertType }) => {
+  switch (type) {
+    case "warning":
+      return {
+        background: theme.colors.warning.c30,
+        color: theme.colors.warning.c100,
+      };
+    case "error":
+      return {
+        background: theme.colors.error.c30,
+        color: theme.colors.error.c100,
+      };
+    case "info":
+    default:
+      return {
+        background: theme.colors.primary.c20,
+        color: theme.colors.primary.c90,
+      };
+  }
+};
+
 const StyledAlertContainer = styled.div<{ type?: AlertType }>`
   ${(p) => {
-    switch (p.type) {
-      case "warning":
-        return css`
-          background: ${p.theme.colors.warning.c30};
-          color: ${p.theme.colors.warning.c100};
-        `;
-      case "error":
-        return css`
-          background: ${p.theme.colors.error.c30};
-          color: ${p.theme.colors.error.c100};
-        `;
-      case "info":
-      default:
-        return css`
-          background: ${p.theme.colors.primary.c20};
-          color: ${p.theme.colors.primary.c90};
-        `;
-    }
+    const { background, color } = getColors({ theme: p.theme, type: p.type });
+    return css`
+      background: ${background};
+      color: ${color};
+    `;
   }}
+  word-break: break-all;
 
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
   padding: 16px;
@@ -53,13 +65,29 @@ const StyledAlertContainer = styled.div<{ type?: AlertType }>`
   align-items: center;
 `;
 
-export default function Alert({ type = "info", title, showIcon = true }: AlertProps): JSX.Element {
+const ContentContainer = styled(Flex)`
+  flex-direction: column;
+`;
+
+export default function Alert({
+  type = "info",
+  title,
+  showIcon = true,
+  renderContent,
+}: AlertProps): JSX.Element {
+  const theme = useTheme();
+  const { color } = getColors({ theme, type });
   return (
     <StyledAlertContainer type={type}>
       {showIcon && !!icons[type] && <StyledIconContainer>{icons[type]}</StyledIconContainer>}
-      <Text variant={"body"} color={"inherit"}>
-        {title}
-      </Text>
+      <ContentContainer rowGap="6px">
+        {title && (
+          <Text variant="paragraph" fontWeight="medium" color="inherit">
+            {title}
+          </Text>
+        )}
+        {renderContent && renderContent({ color })}
+      </ContentContainer>
     </StyledAlertContainer>
   );
 }


### PR DESCRIPTION
### Alert component
- Add the possibility to render more than just text, with the right styles, using a `renderContent` prop
- Fix text styling (variant and fontWeight)
- Document props & storybook

[**Figma for reference**](https://www.figma.com/file/WXCEmRMwW47ELrFonzPTGg/LLD-%2F-Library?node-id=5021%3A28861)

<img width="678" alt="Screenshot 2021-11-30 at 11 51 38" src="https://user-images.githubusercontent.com/91890529/144034075-b7f7cbb2-6368-4054-9d07-df224b5271c7.png">

___

### Link component
- Add `color` prop
- Add `alwaysUnderline` prop to have the link underlined even when text isn't hovered
- Add `textProps` prop to pass down props to rendered Text components thus allowing for more flexibility of this component
- Document props & storybook

<img width="508" alt="Screenshot 2021-11-30 at 11 51 22" src="https://user-images.githubusercontent.com/91890529/144034117-097b4c72-36d3-41d5-bcb0-0e63148ae133.png">


