### PR TITLE
React - RadioElement - New style with outlined padded box

### DIFF
--- a/packages/react/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/form/Radio/Radio.stories.tsx
@@ -52,8 +52,34 @@ const TemplateElement = (args: RadioProps) => {
   );
 };
 
+const TemplateOutlinedElement = (args: RadioProps) => {
+  const [currentArgs, updateArgs] = useArgs();
+  const handleChange: RadioProps["onChange"] = (value) => {
+    // toggle the checked value on click to simulate onChange
+    updateArgs({ currentValue: value });
+    // trigger the storybook action
+    currentArgs.onChange(value);
+  };
+
+  return (
+    <Radio
+      {...args}
+      onChange={handleChange}
+      containerProps={{ flexDirection: "column", rowGap: "20px" }}
+    >
+      <Radio.Element outlined label="Black squad" value="black" variant="main" />
+      <Radio.Element outlined label="Yellow squad" value="yellow" variant="success" />
+      <Radio.Element outlined label="Core squad" value="core" variant="error" />
+    </Radio>
+  );
+};
+
 export const RadioGroup: StoryTemplate<RadioProps> = TemplateElement.bind({
   currentValue: "purple",
+});
+
+export const RadioGroupOutlined: StoryTemplate<RadioProps> = TemplateOutlinedElement.bind({
+  currentValue: "black",
 });
 
 const TemplateListElement = (args: RadioProps) => {

--- a/packages/react/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/form/Radio/Radio.stories.tsx
@@ -43,6 +43,7 @@ const TemplateElement = (args: RadioProps) => {
       containerProps={{ flexDirection: "column", rowGap: "1rem" }}
     >
       <Radio.Element label="Blue squad" value="blue" variant="default" />
+      <Radio.Element label="Black squad" value="black" variant="main" />
       <Radio.Element label="Yellow squad" value="yellow" variant="success" />
       <Radio.Element label="Core squad" value="core" variant="error" />
       <Radio.Element label="Orange squad" value="orange" variant="default" disabled />

--- a/packages/react/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/form/Radio/Radio.stories.tsx
@@ -78,9 +78,7 @@ export const RadioGroup: StoryTemplate<RadioProps> = TemplateElement.bind({
   currentValue: "purple",
 });
 
-export const RadioGroupOutlined: StoryTemplate<RadioProps> = TemplateOutlinedElement.bind({
-  currentValue: "black",
-});
+export const RadioGroupOutlined: StoryTemplate<RadioProps> = TemplateOutlinedElement.bind({});
 
 const TemplateListElement = (args: RadioProps) => {
   const [currentArgs, updateArgs] = useArgs();

--- a/packages/react/src/components/form/Radio/RadioElement.tsx
+++ b/packages/react/src/components/form/Radio/RadioElement.tsx
@@ -1,5 +1,5 @@
 import React, { InputHTMLAttributes, useContext, useMemo } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { rgba } from "../../../styles/helpers";
 import Text from "../../asorted/Text";
@@ -56,9 +56,7 @@ const Input = styled.input`
     :hover {
       --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c90};
     }
-    :active {
-      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c100};
-    }
+    :active,
     :checked,
     :focus {
       --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c100};
@@ -97,10 +95,67 @@ const Input = styled.input`
   }
 `;
 
-const RadioElement = styled.label.attrs({ tabIndex: -1 })`
+const outlinedCSS = css`
+  padding: 20px;
+  border: 1px solid ${(p) => p.theme.colors.neutral.c50};
+  border-radius: ${(p) => p.theme.radii[2]}px;
+  &[data-variant="default"] {
+    :hover {
+      border-color: ${(p) => p.theme.colors.primary.c90};
+    }
+    &[data-checked] :active {
+      border-color: ${(p) => p.theme.colors.primary.c100};
+    }
+    :focus {
+      border-color: ${(p) => p.theme.colors.primary.c80};
+    }
+  }
+
+  &[data-variant="main"] {
+    :hover {
+      border-color: ${(p) => p.theme.colors.neutral.c90};
+    }
+    &[data-checked],
+    :active :focus {
+      border-color: ${(p) => p.theme.colors.neutral.c100};
+    }
+  }
+
+  &[data-variant="success"] {
+    &[data-checked]:not([disabled]) {
+      border-color: ${(p) => p.theme.colors.success.c100};
+    }
+    :hover {
+      border-color: ${(p) => p.theme.colors.success.c100};
+    }
+  }
+
+  &[data-variant="error"] {
+    &[data-checked]:not([disabled]) {
+      border-color: ${(p) => p.theme.colors.error.c100};
+    }
+    :hover {
+      border-color: ${(p) => p.theme.colors.error.c100};
+    }
+  }
+
+  &[data-variant]:disabled {
+    border-color: ${(p) => p.theme.colors.neutral.c40};
+    cursor: unset;
+  }
+`;
+
+const RadioElement = styled.label.attrs({ tabIndex: -1 })<{
+  outlined?: boolean;
+}>`
   display: inline-flex;
   column-gap: 0.75rem;
   align-items: center;
+  cursor: pointer;
+  &[data-variant]:disabled {
+    cursor: unset;
+  }
+  ${(p) => p.outlined && outlinedCSS}
 `;
 
 type InputAttributes = Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "onChange" | "name">;
@@ -108,12 +163,14 @@ type InputAttributes = Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "onC
 export type RadioElementProps = InputAttributes & {
   variant?: "default" | "main" | "success" | "error";
   label: string;
+  outlined?: boolean;
 };
 
 const Element = ({
   label,
   value,
   disabled,
+  outlined,
   variant = "default",
   ...props
 }: RadioElementProps): JSX.Element => {
@@ -128,7 +185,11 @@ const Element = ({
   };
 
   return (
-    <RadioElement>
+    <RadioElement
+      data-variant={variant}
+      {...(isChecked ? { "data-checked": true } : {})}
+      outlined={outlined}
+    >
       <Input
         type="radio"
         data-variant={variant}

--- a/packages/react/src/components/form/Radio/RadioElement.tsx
+++ b/packages/react/src/components/form/Radio/RadioElement.tsx
@@ -52,6 +52,22 @@ const Input = styled.input`
     }
   }
 
+  &[data-variant="main"] {
+    :hover {
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c90};
+    }
+    :active {
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c100};
+    }
+    :checked,
+    :focus {
+      --ledger-ui-checkbox-color: ${(p) => p.theme.colors.neutral.c100};
+    }
+    :focus {
+      box-shadow: 0px 0px 0px 4px ${(p) => rgba(p.theme.colors.neutral.c60, 0.48)};
+    }
+  }
+
   &[data-variant="success"] {
     :hover,
     :checked:not([disabled]),
@@ -90,7 +106,7 @@ const RadioElement = styled.label.attrs({ tabIndex: -1 })`
 type InputAttributes = Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "onChange" | "name">;
 
 export type RadioElementProps = InputAttributes & {
-  variant?: "default" | "success" | "error";
+  variant?: "default" | "main" | "success" | "error";
   label: string;
 };
 


### PR DESCRIPTION
- Add `outline` prop to RadioElement to add an outlined padded box around the radio & label
- Add `variant="main"` prop for a neutral colored radio

[Figma for ref](https://www.figma.com/file/WXCEmRMwW47ELrFonzPTGg/LLD-%2F-Library?node-id=4568%3A32692)

https://user-images.githubusercontent.com/91890529/144465975-bef64c8c-4ab0-445e-a16a-6123f6fe8fdd.mov


