### PR TITLE
Export Boxed Icon as a standalone component

### DIFF
--- a/packages/react/src/components/asorted/index.ts
+++ b/packages/react/src/components/asorted/index.ts
@@ -1,3 +1,3 @@
 export { default as Divider } from "./Divider";
-export { default as Icon, IconBox } from "./Icon";
+export { default as Icon, IconBox, BoxedIcon } from "./Icon";
 export { default as Text } from "./Text";


### PR DESCRIPTION
We have a Boxed Icon component available on our storybook but it isn't exported as a part of the library. This PR fixes that.