### PR TITLE
React - ProgressLoader - Add more customization possibilities

### DIFF
--- a/packages/react/src/components/loaders/ProgressLoader/ProgressLoader.stories.tsx
+++ b/packages/react/src/components/loaders/ProgressLoader/ProgressLoader.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ProgressLoader from "./index";
+import ProgressLoader, { Props } from "./index";
 
 export default {
   title: "Loaders/ProgressLoader",
@@ -23,13 +23,44 @@ export default {
       },
       defaultValue: 6,
     },
+    showPercentage: {
+      defaultValue: true,
+      control: {
+        type: "boolean",
+      },
+    },
+    frontStrokeColor: {
+      type: "string",
+      control: {
+        control: "color",
+      },
+    },
+    backgroundStrokeColor: {
+      type: "string",
+      control: {
+        control: "color",
+      },
+    },
+    textColor: {
+      type: "string",
+      control: {
+        control: "color",
+      },
+    },
   },
 };
 
-export const Default = (args: {
-  radius: number;
-  progress: number;
-  stroke: number;
-}): JSX.Element => {
-  return <ProgressLoader radius={args.radius} progress={args.progress} stroke={args.stroke} />;
+export const Default = (args: Props): JSX.Element => {
+  return (
+    <ProgressLoader
+      radius={args.radius}
+      progress={args.progress}
+      stroke={args.stroke}
+      showPercentage={args.showPercentage}
+      frontStrokeColor={args.frontStrokeColor}
+      backgroundStrokeColor={args.backgroundStrokeColor}
+      frontStrokeLinecap={args.frontStrokeLinecap}
+      textColor={args.textColor}
+    />
+  );
 };

--- a/packages/react/src/components/loaders/ProgressLoader/index.tsx
+++ b/packages/react/src/components/loaders/ProgressLoader/index.tsx
@@ -17,6 +17,32 @@ export interface Props {
    * Progress of the loader, in percent, between 0 and 100.
    */
   progress?: number;
+
+  /**
+   * Whether to display the progress, defaults to true.
+   */
+  showPercentage?: boolean;
+
+  /**
+   * Percentage text color
+   */
+  textColor?: string;
+
+  /**
+   * Front stroke color.
+   */
+  frontStrokeColor?: string;
+
+  /**
+   * Front stroke linecap.
+   * https://developer.mozilla.org/fr/docs/Web/SVG/Attribute/stroke-linecap
+   */
+  frontStrokeLinecap?: "butt" | "round";
+
+  /**
+   * Background stroke color.
+   */
+  backgroundStrokeColor?: string;
 }
 
 const StyledCircle = styled.circle.attrs({
@@ -30,16 +56,14 @@ const StyledCircle = styled.circle.attrs({
 `;
 
 const StyledCircleBackground = styled(StyledCircle).attrs((props) => ({
-  stroke: props.theme.colors.primary.c20,
+  stroke: props.stroke || props.theme.colors.primary.c20,
 }))``;
 
 const StyledCircleFront = styled(StyledCircle).attrs((props) => ({
-  stroke: props.theme.colors.primary.c60,
+  stroke: props.stroke || props.theme.colors.primary.c60,
 }))``;
 
-const StyledCenteredText = styled(Text).attrs({
-  color: "primary.c80",
-})`
+const StyledCenteredText = styled(Text)`
   position: absolute;
   top: 50%;
   left: 50%;
@@ -56,10 +80,16 @@ function ProgressCircleSvg({
   radius,
   stroke,
   progress,
+  backgroundStrokeColor,
+  frontStrokeColor,
+  frontStrokeLinecap,
 }: {
   radius: number;
   stroke: number;
   progress: number;
+  backgroundStrokeColor?: string;
+  frontStrokeColor?: string;
+  frontStrokeLinecap?: "butt" | "round" | "square";
 }) {
   const normalizedRadius = radius - stroke / 2;
   const circumference = normalizedRadius * 2 * Math.PI;
@@ -70,12 +100,15 @@ function ProgressCircleSvg({
         strokeWidth={stroke}
         strokeDasharray={circumference + " " + circumference}
         style={{ strokeDashoffset: 0 }}
+        stroke={backgroundStrokeColor}
         r={normalizedRadius}
       />
       <StyledCircleFront
         strokeWidth={stroke}
         strokeDasharray={circumference + " " + circumference}
         style={{ strokeDashoffset }}
+        stroke={frontStrokeColor}
+        strokeLinecap={frontStrokeLinecap}
         r={normalizedRadius}
       />
     </svg>
@@ -86,11 +119,27 @@ export default function ProgressLoader({
   radius = 32,
   stroke = 6,
   progress = 0,
+  showPercentage = true,
+  textColor,
+  frontStrokeColor,
+  frontStrokeLinecap,
+  backgroundStrokeColor,
 }: Props): JSX.Element {
   return (
     <StyledProgressLoaderContainer>
-      <StyledCenteredText variant="body">{progress}%</StyledCenteredText>
-      <ProgressCircleSvg radius={radius} stroke={stroke} progress={progress} />
+      {showPercentage && (
+        <StyledCenteredText variant="body" color={textColor || "primary.c80"}>
+          {progress}%
+        </StyledCenteredText>
+      )}
+      <ProgressCircleSvg
+        radius={radius}
+        stroke={stroke}
+        progress={progress}
+        frontStrokeColor={frontStrokeColor}
+        frontStrokeLinecap={frontStrokeLinecap}
+        backgroundStrokeColor={backgroundStrokeColor}
+      />
     </StyledProgressLoaderContainer>
   );
 }


### PR DESCRIPTION
Add the following props, allowing stuff like [that](https://www.figma.com/file/7lNG0G4IGF2kphCbef6Gmz/LLD-%2F-Manager?node-id=7%3A3042):

```js
  /**
   * Whether to display the progress, defaults to true.
   */
  showPercentage?: boolean;

  /**
   * Percentage text color
   */
  textColor?: string;

  /**
   * Front stroke color.
   */
  frontStrokeColor?: string;

  /**
   * Front stroke linecap.
   * https://developer.mozilla.org/fr/docs/Web/SVG/Attribute/stroke-linecap
   */
  frontStrokeLinecap?: "butt" | "round";

  /**
   * Background stroke color.
   */
  backgroundStrokeColor?: string;
  ```

