### PR TITLE
chore(react): fix wrong padding placement on Drawer component

### DIFF
--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -12,8 +12,6 @@ const Container = styled(FlexBox)`
   width: 100%;
   height: 100%;
   flex-direction: column;
-  background-color: ${(p) => p.theme.colors.neutral.c00};
-  padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
 `;
 const Header = styled(FlexBox)`
   display: flex;
@@ -30,6 +28,8 @@ const Wrapper = styled.div<{
   height: 100%;
   width: ${(p) =>
     p.big ? p.theme.sizes.drawer.side.big.width : p.theme.sizes.drawer.side.small.width}px;
+  background-color: ${(p) => p.theme.colors.neutral.c00};
+  padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
   display: flex;
   flex-direction: column;
   align-items: stretch;


### PR DESCRIPTION
The element in which the padding was set for the Drawer component was creating some sizing issues when integrating in Ledger Live. This wasn't visible in the Storybook though, I'm not entirely sure why.

Here's a comparison of before and after this change:
**Before**
![before-padding](https://user-images.githubusercontent.com/6013294/145437635-8e307ad4-8029-4ae7-89b1-7e2ecf76a3d0.PNG)
**After**
![after-padding](https://user-images.githubusercontent.com/6013294/145437658-6bfa08b5-20b8-4d08-abbc-c3f0a2625ad4.PNG)

