### PR TITLE
Upgrade react-select

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -19,12 +19,12 @@
     }
   },
   "scripts": {
-    "build": "npm run clean && node scripts/buildReactIcons && tsc && node scripts/transpile",
+    "build": "npm run clean && node scripts/buildReactIcons && tsc --noEmit false && node scripts/transpile",
     "prepublishOnly": "npm run build",
     "clean": "rimraf react native src/react src/native"
   },
   "dependencies": {
-    "@types/styled-components": "^5.1.14",
+    "@types/styled-components": "^5.1.15",
     "styled-components": "^5.2.3"
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf react native src/react src/native"
   },
   "dependencies": {
-    "@types/styled-components": "^5.1.15",
+    "@types/styled-components": "^5.1.14",
     "styled-components": "^5.2.3"
   },
   "devDependencies": {
@@ -32,7 +32,7 @@
     "@svgr/plugin-svgo": "^5.5.0",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "@types/styled-components": "^5.1.15",
+    "@types/styled-components": "^5.1.14",
     "@types/styled-components-react-native": "^5.1.3",
     "@types/styled-system": "^5.1.13",
     "camelcase": "^6.2.1",

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -10,7 +10,8 @@
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": ".",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "react", "native"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,6 @@
     "@types/color": "^3.0.2",
     "@types/react": "~17.0.37",
     "@types/react-dom": "^17.0.11",
-    "@types/react-select": "^4.0.18",
     "@types/react-transition-group": "^4.4.2",
     "@types/react-window": "^1.8.5",
     "@types/styled-components": "^5.1.14",
@@ -58,7 +57,7 @@
     "moment": "^2.29.1",
     "react-chartjs-2": "^3.0.5",
     "react-is": "^17.0.2",
-    "react-select": "^3.2.0",
+    "react-select": "^5.2.1",
     "react-transition-group": "^4.4.2",
     "react-window": "^1.8.6",
     "styled-system": "^5.1.5"

--- a/packages/react/src/components/form/Dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/form/Dropdown/Dropdown.stories.tsx
@@ -22,9 +22,10 @@ const options = [
   { value: "lemon", label: "Lemon" },
   { value: "vanilla", label: "Vanilla" },
 ];
+type Option = typeof options[0];
 
-export const Dropdown = (args: DropdownProps): React.ReactNode => {
-  const [value, setValue] = React.useState<typeof options[0] | null>(null);
+export const Dropdown = (args: DropdownProps<Option>): React.ReactNode => {
+  const [value, setValue] = React.useState<Option | null>(null);
 
   return (
     <DropdownComponent

--- a/packages/react/src/components/form/Dropdown/index.tsx
+++ b/packages/react/src/components/form/Dropdown/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { components, ControlProps, OptionTypeBase, ValueContainerProps } from "react-select";
+import { components, GroupBase, ControlProps, ValueContainerProps } from "react-select";
 import { useTheme } from "styled-components";
 import SelectInput, { Props as SelectInputProps } from "../../form/SelectInput";
 import Text from "../../asorted/Text";
@@ -7,13 +7,15 @@ import { ValueContainer } from "../../form/SelectInput/ValueContainer";
 import { ChevronBottomMedium, ChevronTopMedium } from "@ledgerhq/icons-ui/react";
 import FlexBox from "../../layout/Flex";
 
-export type Props = SelectInputProps & { label: string };
+export type Props<O> = SelectInputProps<O, false, GroupBase<O>> & {
+  label: string;
+};
 
-function DropdownControl<T, M extends boolean = false>(props: ControlProps<T, M>) {
-  const {
-    selectProps: { label },
-    children,
-  } = props;
+function DropdownControl<O, M extends boolean, G extends GroupBase<O>>(
+  props: ControlProps<O, M, G>,
+) {
+  const { selectProps, children } = props;
+  const { label } = selectProps as unknown as Props<O>;
 
   return (
     <components.Control {...props}>
@@ -25,9 +27,7 @@ function DropdownControl<T, M extends boolean = false>(props: ControlProps<T, M>
   );
 }
 
-function DropdownValueContainer<T extends OptionTypeBase = { label: string; value: string }>(
-  props: ValueContainerProps<T, false>,
-) {
+function DropdownValueContainer<O>(props: ValueContainerProps<O, false>) {
   const ChevronIcon = props.selectProps.menuIsOpen ? ChevronTopMedium : ChevronBottomMedium;
 
   return (
@@ -51,7 +51,7 @@ function DropdownIndicatorsContainer() {
   return null;
 }
 
-export default function Dropdown(props: Props): JSX.Element {
+export default function Dropdown<O>(props: Props<O>): JSX.Element {
   const theme = useTheme();
   const { styles, ...rest } = props;
 

--- a/packages/react/src/components/form/SelectInput/Control.tsx
+++ b/packages/react/src/components/form/SelectInput/Control.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { components, Styles, ControlProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, StylesConfig, ControlProps } from "react-select";
 import { DefaultTheme } from "styled-components";
 import { InputContainer } from "../BaseInput";
+import { Props as SelectProps } from "./index";
 
 export function getStyles<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(theme: DefaultTheme): NonNullable<Styles<T, M>["control"]> {
+  G extends GroupBase<O> = GroupBase<O>,
+>(theme: DefaultTheme): NonNullable<StylesConfig<O, M, G>["control"]> {
   return (provided) => ({
     ...provided,
     display: "flex",
@@ -21,14 +23,13 @@ export function getStyles<
 }
 
 export function Control<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: ControlProps<T, M>): JSX.Element {
-  const {
-    isFocused,
-    selectProps: { isDisabled, error, renderLeft },
-    children,
-  } = props;
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: ControlProps<O, M, G>): JSX.Element {
+  const { isFocused, selectProps, children } = props;
+
+  const { isDisabled, error, renderLeft } = selectProps as SelectProps<O, M, G>;
 
   return (
     <InputContainer disabled={isDisabled} error={error} focus={isFocused}>

--- a/packages/react/src/components/form/SelectInput/DropdownIndicator.tsx
+++ b/packages/react/src/components/form/SelectInput/DropdownIndicator.tsx
@@ -1,13 +1,14 @@
 import React from "react";
-import { components, Styles, IndicatorProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, StylesConfig, DropdownIndicatorProps } from "react-select";
 import { useTheme } from "styled-components";
 import Text from "../../asorted/Text";
 import { ChevronBottomMedium, ChevronTopMedium } from "@ledgerhq/icons-ui/react";
 
 export function getStyles<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(): NonNullable<Styles<T, M>["dropdownIndicator"]> {
+  G extends GroupBase<O> = GroupBase<O>,
+>(): NonNullable<StylesConfig<O, M, G>["dropdownIndicator"]> {
   return (provided) => ({
     ...provided,
     padding: 0,
@@ -15,9 +16,10 @@ export function getStyles<
 }
 
 export function DropdownIndicator<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: IndicatorProps<T, M>): JSX.Element {
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: DropdownIndicatorProps<O, M, G>): JSX.Element {
   const theme = useTheme();
   const { isDisabled } = props.selectProps;
 

--- a/packages/react/src/components/form/SelectInput/IndicatorsContainer.tsx
+++ b/packages/react/src/components/form/SelectInput/IndicatorsContainer.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { components, IndicatorContainerProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, IndicatorsContainerProps } from "react-select";
 import FlexBox from "../../layout/Flex";
+import { Props as SelectProps } from "./index";
 
 export function IndicatorsContainer<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: IndicatorContainerProps<T, M>): JSX.Element {
-  const {
-    selectProps: { renderRight },
-  } = props;
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: IndicatorsContainerProps<O, M, G>): JSX.Element {
+  const { renderRight } = props.selectProps as SelectProps<O, M, G>;
 
   return (
     <FlexBox alignItems="center">

--- a/packages/react/src/components/form/SelectInput/MenuList.tsx
+++ b/packages/react/src/components/form/SelectInput/MenuList.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { components, Styles, MenuListComponentProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, StylesConfig, MenuListProps } from "react-select";
 import { DefaultTheme } from "styled-components";
 
 export function getStyles<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(theme: DefaultTheme): NonNullable<Styles<T, M>["menuList"]> {
+  G extends GroupBase<O> = GroupBase<O>,
+>(theme: DefaultTheme): NonNullable<StylesConfig<O, M, G>["menuList"]> {
   return (provided) => ({
     ...provided,
     display: "flex",
@@ -21,8 +22,9 @@ export function getStyles<
 }
 
 export function MenuList<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: MenuListComponentProps<T, M>): JSX.Element {
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: MenuListProps<O, M, G>): JSX.Element {
   return <components.MenuList {...props}>{props.children}</components.MenuList>;
 }

--- a/packages/react/src/components/form/SelectInput/Option.tsx
+++ b/packages/react/src/components/form/SelectInput/Option.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { components, Styles, OptionProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, StylesConfig, OptionProps } from "react-select";
 import styled from "styled-components";
 import Text from "../../asorted/Text";
 
 export function getStyles<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(): NonNullable<Styles<T, M>["option"]> {
+  G extends GroupBase<O> = GroupBase<O>,
+>(): NonNullable<StylesConfig<O, M, G>["option"]> {
   return (provided) => ({
     ...provided,
     display: "flex",
@@ -74,20 +75,23 @@ const Wrapper = styled(Text).attrs({ as: "div" })<{
 `;
 
 export type ExtraProps<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
+  G extends GroupBase<O> = GroupBase<O>,
 > = {
   /* A render function to customize the contents. */
-  render?: (props: React.PropsWithChildren<OptionProps<T, M>>) => React.ReactNode;
+  render?: (props: React.PropsWithChildren<OptionProps<O, M, G>>) => React.ReactNode;
 };
 export type Props<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
-> = OptionProps<T, M> & ExtraProps<T, M>;
+  G extends GroupBase<O> = GroupBase<O>,
+> = OptionProps<O, M, G> & ExtraProps<O, M, G>;
 export function Option<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: Props<T, M>): JSX.Element {
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: Props<O, M, G>): JSX.Element {
   const { render, children, ...innerProps } = props;
 
   return (

--- a/packages/react/src/components/form/SelectInput/Select.stories.tsx
+++ b/packages/react/src/components/form/SelectInput/Select.stories.tsx
@@ -4,6 +4,7 @@ import { OptionProps, ValueContainerProps } from "react-select";
 
 import Text from "../../asorted/Text";
 import Flex from "../../layout/Flex";
+import Grid from "../../layout/Grid";
 import SearchMedium from "@ledgerhq/icons-ui/react/SearchMedium";
 import SelectInput, { Props } from "./index";
 import { Option } from "./Option";
@@ -324,7 +325,9 @@ const ColorOption = (props: OptionProps<SelectItem, false>) => {
       render={({ children }) => (
         <Flex flex={1} py={2} alignItems="center">
           <Flex mr={4} p={4} style={{ background: props.data.value }} />
-          <Flex flex={1}>{children}</Flex>
+          <Flex flex={1} style={{ textTransform: "capitalize" }}>
+            {children}
+          </Flex>
         </Flex>
       )}
     />
@@ -333,13 +336,17 @@ const ColorOption = (props: OptionProps<SelectItem, false>) => {
 const ColorValueContainer = (props: ValueContainerProps<SelectItem, false>) => {
   return (
     <ValueContainer
-      render={({ children }) => <div style={{ textTransform: "capitalize" }}>{children}</div>}
+      render={({ children }) => (
+        <Grid alignItems="center" style={{ textTransform: "capitalize" }}>
+          {children}
+        </Grid>
+      )}
       {...props}
     />
   );
 };
 
-export const Default: StoryTemplate<Props> = (args) => {
+export const Default: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>(null);
 
   return (
@@ -359,7 +366,7 @@ export const Default: StoryTemplate<Props> = (args) => {
   );
 };
 
-export const Minimal: StoryTemplate<Props> = (args) => {
+export const Minimal: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>(null);
 
   return (
@@ -381,7 +388,7 @@ Minimal.parameters = {
   },
 };
 
-export const SideRenders: StoryTemplate<Props> = (args) => {
+export const SideRenders: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>(null);
   const theme = useTheme();
 
@@ -420,7 +427,7 @@ const CustomOption = (props: OptionProps<SelectItem, false>) => {
     <Option
       {...props}
       render={({ children }) => (
-        <Flex flex={1}>
+        <Flex flex={1} alignItems="center">
           <Text fontWeight="semiBold" variant={"paragraph"} mr={4}>
             #Left
           </Text>
@@ -435,7 +442,7 @@ const CustomOption = (props: OptionProps<SelectItem, false>) => {
     />
   );
 };
-export const CustomOptions: StoryTemplate<Props> = (args) => {
+export const CustomOptions: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>();
 
   return (
@@ -458,7 +465,7 @@ CustomOptions.parameters = {
   },
 };
 
-export const DisabledOption: StoryTemplate<Props> = (args) => {
+export const DisabledOption: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>(null);
 
   return (
@@ -483,7 +490,7 @@ DisabledOption.parameters = {
 };
 
 const hugeOptions = new Array(10000).fill(0).map((_, i) => ({ label: "" + i, value: "" + i }));
-export const VirtualList: StoryTemplate<Props> = (args) => {
+export const VirtualList: StoryTemplate<Props<SelectItem>> = (args) => {
   const [value, setValue] = React.useState<SelectItem | null>(null);
 
   return (
@@ -507,4 +514,19 @@ VirtualList.parameters = {
         "This control contains a list of 10_000 elements. It uses the `VirtualMenuList` component to render the list inside a `react-window` wrapper.",
     },
   },
+};
+
+export const MultiSelect: StoryTemplate<Props<SelectItem, true>> = (args) => {
+  const [value, setValue] = React.useState<readonly SelectItem[]>([]);
+
+  return (
+    <SelectInput
+      isMulti
+      options={options}
+      value={value}
+      onChange={setValue}
+      menuPortalTarget={document.body}
+      {...args}
+    />
+  );
 };

--- a/packages/react/src/components/form/SelectInput/Select.stories.tsx
+++ b/packages/react/src/components/form/SelectInput/Select.stories.tsx
@@ -530,3 +530,11 @@ export const MultiSelect: StoryTemplate<Props<SelectItem, true>> = (args) => {
     />
   );
 };
+
+MultiSelect.parameters = {
+  docs: {
+    description: {
+      story: "A standard selector with multiselection using the `isMulti` prop.",
+    },
+  },
+};

--- a/packages/react/src/components/form/SelectInput/ValueContainer.tsx
+++ b/packages/react/src/components/form/SelectInput/ValueContainer.tsx
@@ -29,7 +29,7 @@ export function ValueContainer<
         as="div"
         variant="paragraph"
         color={color}
-        style={{ display: "grid", alignItems: "center" }}
+        style={{ display: "inherit", alignItems: "center" }}
       >
         {props.render ? props.render(props) : props.children}
       </Text>

--- a/packages/react/src/components/form/SelectInput/ValueContainer.tsx
+++ b/packages/react/src/components/form/SelectInput/ValueContainer.tsx
@@ -1,32 +1,36 @@
 import React from "react";
-import { components, Styles, ValueContainerProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, StylesConfig, ValueContainerProps } from "react-select";
 import Text from "../../asorted/Text";
 
 export function getStyles<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(): Styles<T, M>["valueContainer"] {
+  G extends GroupBase<O> = GroupBase<O>,
+>(): StylesConfig<O, M, G>["valueContainer"] {
   return (provided) => ({
     ...provided,
     padding: 0,
   });
 }
 
-type ExtraProps<
-  T extends OptionTypeBase = { label: string; value: string },
-  M extends boolean = false,
-> = {
+type ExtraProps<O = unknown, M extends boolean = false, G extends GroupBase<O> = GroupBase<O>> = {
   /* A render function to customize the contents. */
-  render?: (props: React.PropsWithChildren<ValueContainerProps<T, M>>) => React.ReactNode;
+  render?: (props: React.PropsWithChildren<ValueContainerProps<O, M, G>>) => React.ReactNode;
 };
 export function ValueContainer<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: ValueContainerProps<T, M> & ExtraProps<T, M>): JSX.Element {
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: ValueContainerProps<O, M, G> & ExtraProps<O, M, G>): JSX.Element {
   const color = props.selectProps.isDisabled ? "neutral.c60" : "neutral.c100";
   return (
     <components.ValueContainer {...props}>
-      <Text as="div" variant="paragraph" color={color}>
+      <Text
+        as="div"
+        variant="paragraph"
+        color={color}
+        style={{ display: "grid", alignItems: "center" }}
+      >
         {props.render ? props.render(props) : props.children}
       </Text>
     </components.ValueContainer>

--- a/packages/react/src/components/form/SelectInput/VirtualMenuList.tsx
+++ b/packages/react/src/components/form/SelectInput/VirtualMenuList.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useMemo, useRef, useEffect } from "react";
-import { components, MenuListComponentProps, OptionTypeBase } from "react-select";
+import { components, GroupBase, MenuListProps } from "react-select";
 import { FixedSizeList, FixedSizeList as List } from "react-window";
+import { Props as SelectProps } from "./index";
 
 export type RowProps = React.PropsWithChildren<{ style: React.CSSProperties }>;
 export const VirtualRow = memo(({ style, children }: RowProps) => (
@@ -8,17 +9,12 @@ export const VirtualRow = memo(({ style, children }: RowProps) => (
 ));
 
 export function VirtualMenuList<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
->(props: MenuListComponentProps<T, M>): React.ReactElement {
-  const {
-    children,
-    options,
-    maxHeight,
-    getValue,
-    getStyles,
-    selectProps: { noOptionsMessage, rowHeight },
-  } = props;
+  G extends GroupBase<O> = GroupBase<O>,
+>(props: MenuListProps<O, M, G>): React.ReactElement {
+  const { children, options, maxHeight, getValue, getStyles, selectProps } = props;
+  const { noOptionsMessage, rowHeight = 0 } = selectProps as SelectProps<O, M, G>;
 
   const listRef = useRef<FixedSizeList>();
   const [value] = getValue();
@@ -60,7 +56,7 @@ export function VirtualMenuList<
 
   return (
     <div
-      style={{ ...menuStyle, maxHeight: "auto" }}
+      style={{ ...(menuStyle as React.CSSProperties), maxHeight: "auto" }}
       onWheelCapture={(e) =>
         /*
           This event causes issues with react-window.

--- a/packages/react/src/components/form/SelectInput/index.tsx
+++ b/packages/react/src/components/form/SelectInput/index.tsx
@@ -1,5 +1,11 @@
 import React, { memo, useMemo } from "react";
-import Select, { Props as SelectProps, OptionTypeBase, Styles } from "react-select";
+import Select, {
+  Props as SelectProps,
+  ControlProps,
+  IndicatorsContainerProps,
+  GroupBase,
+  StylesConfig,
+} from "react-select";
 import { DefaultTheme, useTheme } from "styled-components";
 import * as DropdownIndicatorModule from "./DropdownIndicator";
 import * as ValueContainerModule from "./ValueContainer";
@@ -9,34 +15,29 @@ import * as OptionModule from "./Option";
 import { IndicatorsContainer } from "./IndicatorsContainer";
 import { InputErrorContainer } from "../BaseInput";
 
-export type SelfProps<
-  T extends OptionTypeBase = { label: string; value: string },
-  M extends boolean = false,
-> = {
+export type SelfProps<O, M extends boolean, G extends GroupBase<O>> = {
   /* An error which will be displayed below the component and will change the style. */
   error?: string;
   /* A component which will be rendered on the left side of the select. */
-  renderLeft?: (props: Props<T, M>) => React.ReactNode;
+  renderLeft?: (props: ControlProps<O, M, G>) => React.ReactNode;
   /* A component which will be rendered on the right side of the select, before the indicators. */
-  renderRight?: (props: Props<T, M>) => React.ReactNode;
+  renderRight?: (props: IndicatorsContainerProps<O, M, G>) => React.ReactNode;
   /* This value is used to calculate the height of the menu list when dealing with virtual lists. */
   rowHeight?: number;
   /* Removes all wrappers when rendering the element. */
   unwrapped?: boolean;
   /* Extends defined styles. */
-  extendStyles?: (styles: Styles<T, M>) => Styles<T, M>;
+  extendStyles?: (styles: StylesConfig<O, M, G>) => StylesConfig<O, M, G>;
 };
 export type Props<
-  T extends OptionTypeBase = { label: string; value: string },
+  O = unknown,
   M extends boolean = false,
-> = SelectProps<T, M> & SelfProps<T, M>;
+  G extends GroupBase<O> = GroupBase<O>,
+> = SelectProps<O, M, G> & SelfProps<O, M, G>;
 
-const stylesFn = <
-  T extends OptionTypeBase = { label: string; value: string },
-  M extends boolean = false,
->(
+const stylesFn = <O, M extends boolean, G extends GroupBase<O>>(
   theme: DefaultTheme,
-): Styles<T, M> => ({
+): StylesConfig<O, M, G> => ({
   control: ControlModule.getStyles(theme),
   valueContainer: ValueContainerModule.getStyles(),
   dropdownIndicator: DropdownIndicatorModule.getStyles(),
@@ -62,13 +63,16 @@ const stylesFn = <
   }),
 });
 
-function SelectInput<
-  T extends OptionTypeBase = { label: string; value: string },
-  M extends boolean = false,
->({ error, rowHeight = 48, unwrapped, extendStyles, ...props }: Props<T, M>): JSX.Element {
+function SelectInput<O, M extends boolean, G extends GroupBase<O>>({
+  error,
+  rowHeight = 48,
+  unwrapped,
+  extendStyles,
+  ...props
+}: Props<O, M, G>): JSX.Element {
   const theme = useTheme();
   const styles = useMemo(
-    () => (extendStyles ? extendStyles(stylesFn<T, M>(theme)) : stylesFn<T, M>(theme)),
+    () => (extendStyles ? extendStyles(stylesFn<O, M, G>(theme)) : stylesFn<O, M, G>(theme)),
     [theme, extendStyles],
   );
   const { isDisabled, components = {} } = props;
@@ -76,13 +80,11 @@ function SelectInput<
   const innerContent = (
     <Select
       {...props}
-      error={error}
       styles={{
         ...styles,
         ...props.styles,
       }}
       classNamePrefix="react-select"
-      rowHeight={rowHeight}
       components={{
         Control: ControlModule.Control,
         ValueContainer: ValueContainerModule.ValueContainer,
@@ -93,6 +95,8 @@ function SelectInput<
         IndicatorSeparator: null,
         ...components,
       }}
+      // @ts-expect-error We want to be able to pass extra props here…
+      rowHeight={rowHeight}
     />
   );
 

--- a/packages/react/src/components/form/SelectInput/index.tsx
+++ b/packages/react/src/components/form/SelectInput/index.tsx
@@ -55,6 +55,23 @@ const stylesFn = <O, M extends boolean, G extends GroupBase<O>>(
     ...provided,
     color: "inherit",
   }),
+  multiValue: (provided) => ({
+    ...provided,
+    backgroundColor: theme.colors.primary.c20,
+    borderRadius: theme.radii[1],
+  }),
+  multiValueLabel: (provided) => ({
+    ...provided,
+    color: theme.colors.neutral.c100,
+  }),
+  multiValueRemove: (provided) => ({
+    ...provided,
+    cursor: "pointer",
+    ":hover": {
+      color: theme.colors.error.c100,
+      backgroundColor: theme.colors.error.c30,
+    },
+  }),
   menu: (provided) => ({
     ...provided,
     border: 0,

--- a/packages/react/src/components/form/SplitInput/SplitInput.stories.tsx
+++ b/packages/react/src/components/form/SplitInput/SplitInput.stories.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { components, OptionTypeBase } from "react-select";
+import { components, StylesConfig } from "react-select";
 import SplitInput, { Props } from "./index";
 import Input from "../BaseInput";
 import QuantityInput from "../QuantityInput";
 import QrCodeInput from "../QrCodeInput";
-import SelectInput from "../SelectInput";
+import SelectInput, { Props as SelectInputProps } from "../SelectInput";
 import FlexBox from "../../layout/Flex";
 import Text from "../../asorted/Text";
 
@@ -42,7 +42,7 @@ const Label = ({ left, right }: { left: string; right: string }) => (
   </FlexBox>
 );
 
-const selectStyles: React.ComponentProps<typeof SelectInput>["styles"] = {
+const selectStyles: StylesConfig<Option> = {
   container: (provided, state) => ({
     ...provided,
     height: "100%",
@@ -58,12 +58,13 @@ const selectStyles: React.ComponentProps<typeof SelectInput>["styles"] = {
   }),
 };
 
+type Option = typeof options[0];
 export const Split = (args: Props): React.ReactNode => {
-  const [leftValue1, setLeftValue1] = React.useState<OptionTypeBase | null>(null);
+  const [leftValue1, setLeftValue1] = React.useState<Option | null>(null);
   const [rightValue1, setRightValue1] = React.useState<string>("");
-  const [leftValue2, setLeftValue2] = React.useState<OptionTypeBase | null>(null);
+  const [leftValue2, setLeftValue2] = React.useState<Option | null>(null);
   const [rightValue2, setRightValue2] = React.useState<string>("");
-  const [leftValue3, setLeftValue3] = React.useState<OptionTypeBase | null>(null);
+  const [leftValue3, setLeftValue3] = React.useState<Option | null>(null);
   const [rightValue3, setRightValue3] = React.useState<string>("");
   const [leftValue4, setLeftValue4] = React.useState<string>("");
   const [rightValue4, setRightValue4] = React.useState<string>("");
@@ -73,7 +74,7 @@ export const Split = (args: Props): React.ReactNode => {
       <Label left="SelectInput" right="Input" />
       <SplitInput
         {...args}
-        renderLeft={(props) => (
+        renderLeft={(props: SelectInputProps<Option>) => (
           <SelectInput
             value={leftValue1}
             options={options}
@@ -101,7 +102,7 @@ export const Split = (args: Props): React.ReactNode => {
       <Label left="SelectInput" right="QuantityInput" />
       <SplitInput
         {...args}
-        renderLeft={(props) => (
+        renderLeft={(props: SelectInputProps<Option>) => (
           <SelectInput
             value={leftValue2}
             options={options}
@@ -129,7 +130,7 @@ export const Split = (args: Props): React.ReactNode => {
       <Label left="SelectInput" right="QrCodeInput" />
       <SplitInput
         {...args}
-        renderLeft={(props) => (
+        renderLeft={(props: SelectInputProps<Option>) => (
           <SelectInput
             value={leftValue3}
             options={options}

--- a/packages/react/src/components/navigation/Breadcrumb/index.tsx
+++ b/packages/react/src/components/navigation/Breadcrumb/index.tsx
@@ -56,7 +56,7 @@ export default memo(function Breadcrumb({ segments, onChange }: Props): JSX.Elem
               onChange={(elt) => elt && onChange([...values, elt.value])}
               styles={{
                 control: (provided, state) => ({
-                  ...ControlModule.getStyles(theme)(provided, state),
+                  ...ControlModule.getStyles<Element>(theme)(provided, state),
                   cursor: "pointer",
                 }),
                 singleValue: (provided) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,7 +1209,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.16.3":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -1281,6 +1281,17 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.6.0":
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.6.0.tgz#65fbdbbe4382f1991d8b20853c38e63ecccec9a1"
+  integrity sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.10"
+
 "@emotion/core@^10.0.20", "@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
@@ -1338,6 +1349,19 @@
   dependencies:
     css-to-react-native "^2.2.1"
 
+"@emotion/react@^11.1.1":
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.0.tgz#b179da970ac0e8415de3ac165deadf8d9c4bf89f"
+  integrity sha512-WL93hf9+/2s3cA1JVJlz8+Uy6p6QWukqQFOm2OZO5ki51hfucHMOmbSjiyC3t2Y4RI8XUmBoepoc/24ny/VBbA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/cache" "^11.6.0"
+    "@emotion/serialize" "^1.0.2"
+    "@emotion/sheet" "^1.1.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
@@ -1349,7 +1373,7 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
-"@emotion/serialize@^1.0.0":
+"@emotion/serialize@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
   integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
@@ -1364,6 +1388,11 @@
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
+  integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
 
 "@emotion/styled-base@^10.0.27":
   version "10.0.31"
@@ -1403,7 +1432,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
-"@emotion/weak-memoize@0.2.5":
+"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -3912,7 +3941,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@*", "@types/react-dom@^17.0.11":
+"@types/react-dom@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
@@ -3933,16 +3962,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-select@^4.0.18":
-  version "4.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.18.tgz#f907f406411afa862217a9d86c54a301367a35c1"
-  integrity sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==
-  dependencies:
-    "@emotion/serialize" "^1.0.0"
-    "@types/react" "*"
-    "@types/react-dom" "*"
-    "@types/react-transition-group" "*"
-
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
@@ -3950,7 +3969,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@*", "@types/react-transition-group@^4.4.2":
+"@types/react-transition-group@^4.4.0", "@types/react-transition-group@^4.4.2":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
   integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
@@ -9913,7 +9932,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -14999,6 +15018,19 @@ react-select@^3.2.0:
     react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
+react-select@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.1.tgz#416c25c6b79b94687702374e019c4f2ed9d159d6"
+  integrity sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.1.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+
 react-sizeme@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.2.tgz#4a2f167905ba8f8b8d932a9e35164e459f9020e4"
@@ -16660,6 +16692,11 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 subscriptions-transport-ws@0.9.8:
   version "0.9.8"


### PR DESCRIPTION
### Upgrade the `react-select` package

- Up from v3 to v5
- Fixed vscode 1000+ ts errors caused by an issue in the tsconfig file
- Fix style when having a select with multi selection

Is not JS-breaking but TS typings have been completely rewritten by the `react-select` team, so it will most likely break typescript compatibility.

<img width="612" alt="Capture d’écran 2021-12-10 à 11 11 06" src="https://user-images.githubusercontent.com/3428394/145556953-7b821778-2320-4dfc-9006-d71827bce956.png">

