### PR TITLE
Add background color to side drawer component

### DIFF
--- a/packages/react/src/components/layout/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/layout/Drawer/Drawer.stories.tsx
@@ -27,6 +27,12 @@ export default {
       },
       required: false,
     },
+    backgroundColor: {
+      control: {
+        type: "color",
+        presetColors: ["coral", "tomato", "orange", "blue", "purple"],
+      },
+    },
     big: {
       type: "boolean",
       value: true,
@@ -39,7 +45,7 @@ export default {
   },
 };
 
-const Template = ({ title, big }: DrawerProps) => {
+const Template = ({ title, big, backgroundColor }: DrawerProps) => {
   const [{ isOpen }, updateArgs] = useArgs();
 
   return (
@@ -47,7 +53,13 @@ const Template = ({ title, big }: DrawerProps) => {
       <Button variant={"main"} onClick={() => updateArgs({ isOpen: true })} style={{ flex: 1 }}>
         Open
       </Button>
-      <Drawer isOpen={isOpen} onClose={() => updateArgs({ isOpen: false })} title={title} big={big}>
+      <Drawer
+        isOpen={isOpen}
+        onClose={() => updateArgs({ isOpen: false })}
+        title={title}
+        big={big}
+        backgroundColor={backgroundColor}
+      >
         <Flex flexDirection={"column"}>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed elit mi, tempus sed justo

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -8,10 +8,13 @@ import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
 import Text from "../../asorted/Text";
 
-const Container = styled(FlexBox)`
+const Container = styled(FlexBox)<{
+  backgroundColor?: string;
+}>`
   width: 100%;
   height: 100%;
   flex-direction: column;
+  background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
 `;
 const Header = styled(FlexBox)`
   display: flex;
@@ -28,7 +31,6 @@ const Wrapper = styled.div<{
   height: 100%;
   width: ${(p) =>
     p.big ? p.theme.sizes.drawer.side.big.width : p.theme.sizes.drawer.side.small.width}px;
-  background-color: ${(p) => p.theme.colors.neutral.c00};
   padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
   display: flex;
   flex-direction: column;
@@ -71,6 +73,7 @@ export interface DrawerProps {
   children: React.ReactNode;
   title?: React.ReactNode;
   big?: boolean;
+  backgroundColor?: string;
   onClose: () => void;
   onBack?: () => void;
   setTransitionsEnabled?: (arg0: boolean) => void;
@@ -83,6 +86,7 @@ const DrawerContent = ({
   children,
   big,
   onClose,
+  backgroundColor,
   setTransitionsEnabled = () => 0,
   onBack,
   hideNavigation = true,
@@ -108,7 +112,7 @@ const DrawerContent = ({
       <Overlay>
         <TransitionSlide in={isOpen} fixed reverseExit appear mountOnEnter unmountOnExit>
           <Wrapper big={big}>
-            <Container>
+            <Container backgroundColor={backgroundColor}>
               <Header>
                 {!hideNavigation && (
                   <>

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -8,13 +8,10 @@ import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
 import Text from "../../asorted/Text";
 
-const Container = styled(FlexBox)<{
-  backgroundColor?: string;
-}>`
+const Container = styled(FlexBox)`
   width: 100%;
   height: 100%;
   flex-direction: column;
-  background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
 `;
 const Header = styled(FlexBox)`
   display: flex;
@@ -27,11 +24,13 @@ const Wrapper = styled.div<{
   big?: boolean;
   width?: number;
   height?: number;
+  backgroundColor?: string;
 }>`
   height: 100%;
   width: ${(p) =>
     p.big ? p.theme.sizes.drawer.side.big.width : p.theme.sizes.drawer.side.small.width}px;
   padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
+  background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -111,8 +110,8 @@ const DrawerContent = ({
     >
       <Overlay>
         <TransitionSlide in={isOpen} fixed reverseExit appear mountOnEnter unmountOnExit>
-          <Wrapper big={big}>
-            <Container backgroundColor={backgroundColor}>
+          <Wrapper big={big} backgroundColor={backgroundColor}>
+            <Container>
               <Header>
                 {!hideNavigation && (
                   <>


### PR DESCRIPTION
Adds a background color prop for the side drawer as some of the screens in our rebranding will need it
![drawer-background-color](https://user-images.githubusercontent.com/6013294/145582237-c7cd4217-5ea6-4300-aa14-8f5c651d6b25.gif)
