### PR TITLE
React - Alert - Add renderRight & containerProps

### DIFF
--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -37,6 +37,7 @@ export const WithContent = (args: AlertProps) => {
   return (
     <Alert
       {...args}
+      containerProps={{ pr: 7 }}
       renderContent={({ color, textProps }) => (
         <>
           <Text color="inherit" {...textProps}>

--- a/packages/react/src/components/message/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/message/Alert/Alert.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Alert, { AlertProps } from "./index";
 import Link from "../../cta/Link";
 import Text from "../../asorted/Text";
+import Button from "../../cta/Button";
 import { Icons } from "../../../../src/assets";
 export default {
   title: "Messages/Alerts",
@@ -53,6 +54,7 @@ export const WithContent = (args: AlertProps) => {
           </Link>
         </>
       )}
+      renderRight={() => <Button variant="color">Click me</Button>}
     />
   );
 };

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -9,22 +9,36 @@ import CircledAlertMedium from "@ledgerhq/icons-ui/react/CircledAlertMedium";
 import { DefaultTheme } from "styled-components/native";
 
 type AlertType = "info" | "warning" | "error";
+
+type RenderProps = (props: {
+  color: string;
+  textProps: { variant?: TextVariants; fontWeight?: string };
+}) => JSX.Element;
+
 export interface AlertProps {
   /**
-   * Affects the colors of the background & text and what icon can be displayed
+   * Affects the colors of the background & text and what icon can be displayed.
    */
   type?: AlertType;
   /**
-   * Title of the Alert
+   * Title of the Alert.
    */
   title?: string;
   /**
-   * Method for rendering additional content under the title `{ color: string; textProps: { variant?: TextVariants; fontWeight?: string } }` is passed as props to easily style text elements
+   * Method for rendering additional content under the title. `{ color: string; textProps: { variant?: TextVariants; fontWeight?: string } }` is passed as props to easily style text elements.
    */
-  renderContent?: (props: {
-    color: string;
-    textProps: { variant?: TextVariants; fontWeight?: string };
-  }) => JSX.Element;
+  renderContent?: RenderProps;
+
+  /**
+   * Method for rendering additional content to the right. `{ color: string; textProps: { variant?: TextVariants; fontWeight?: string } }` is passed as props to easily style text elements.
+   */
+  renderRight?: RenderProps;
+
+  /**
+   * Additional props to be passed to the top level container (containing icon + content).
+   */
+  containerProps?: Record<string, unknown>;
+
   /**
    * Whether or not to display an icon
    */
@@ -76,6 +90,8 @@ export default function Alert({
   title,
   showIcon = true,
   renderContent,
+  renderRight,
+  containerProps,
 }: AlertProps): JSX.Element {
   const theme = useTheme();
   const { color, background } = getColors({ theme, type });
@@ -84,9 +100,9 @@ export default function Alert({
     fontWeight: "medium",
   };
   return (
-    <StyledAlertContainer color={color} backgroundColor={background}>
+    <StyledAlertContainer color={color} backgroundColor={background} {...containerProps}>
       {showIcon && !!icons[type] && <StyledIconContainer>{icons[type]}</StyledIconContainer>}
-      <Flex flexDirection="column" alignItems="flex-start" rowGap="6px">
+      <Flex flexDirection="column" flex={1} alignItems="flex-start" rowGap="6px">
         {title && (
           <Text {...textProps} color="inherit">
             {title}
@@ -94,6 +110,7 @@ export default function Alert({
         )}
         {renderContent && renderContent({ color, textProps })}
       </Flex>
+      <Flex>{renderRight && renderRight({ color, textProps })}</Flex>
     </StyledAlertContainer>
   );
 }

--- a/packages/react/src/components/message/Alert/index.tsx
+++ b/packages/react/src/components/message/Alert/index.tsx
@@ -78,9 +78,7 @@ const getColors = ({ theme, type }: { theme: DefaultTheme; type?: AlertType }) =
   }
 };
 
-const StyledAlertContainer = styled(Flex).attrs(() => ({
-  padding: 6,
-}))<{ background?: string; color?: string }>`
+const StyledAlertContainer = styled(Flex)<{ background?: string; color?: string }>`
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
   align-items: center;
 `;
@@ -100,7 +98,12 @@ export default function Alert({
     fontWeight: "medium",
   };
   return (
-    <StyledAlertContainer color={color} backgroundColor={background} {...containerProps}>
+    <StyledAlertContainer
+      color={color}
+      backgroundColor={background}
+      padding={6}
+      {...containerProps}
+    >
       {showIcon && !!icons[type] && <StyledIconContainer>{icons[type]}</StyledIconContainer>}
       <Flex flexDirection="column" flex={1} alignItems="flex-start" rowGap="6px">
         {title && (


### PR DESCRIPTION
Allows stuff like that (screenshot taken from Figma):
- Custom padding
- Item on the right, centered with content
<img width="451" alt="Screenshot 2021-12-10 at 15 23 55" src="https://user-images.githubusercontent.com/91890529/145588941-0885b9d6-f87c-418c-a81a-f1573c6da334.png">

___
<img width="611" alt="Screenshot 2021-12-10 at 15 23 17" src="https://user-images.githubusercontent.com/91890529/145588821-0cf9d862-7cb7-4f78-b4ed-1ce80e095e80.png">
<img width="846" alt="Screenshot 2021-12-10 at 15 23 26" src="https://user-images.githubusercontent.com/91890529/145588833-b32ecdae-fe65-49be-a24f-ee914a7eda31.png">

