### PR TITLE
Add footer to Drawer component + minor CSS fixes

### DIFF
--- a/packages/react/src/components/layout/Drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/layout/Drawer/Drawer.stories.tsx
@@ -58,6 +58,13 @@ const Template = ({ title, big, backgroundColor }: DrawerProps) => {
         onClose={() => updateArgs({ isOpen: false })}
         title={title}
         big={big}
+        footer={
+          <Flex flex={1} justifyContent="flex-end">
+            <Button variant={"main"} onClick={() => updateArgs({ isOpen: false })}>
+              Close
+            </Button>
+          </Flex>
+        }
         backgroundColor={backgroundColor}
       >
         <Flex flexDirection={"column"}>

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -2,7 +2,8 @@ import React, { useCallback } from "react";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 import FlexBox from "../Flex";
-import Close from "@ledgerhq/icons-ui/react/CloseRegular";
+import Divider from "../../asorted/Divider";
+import Close from "@ledgerhq/icons-ui/react/CloseMedium";
 import ArrowLeft from "@ledgerhq/icons-ui/react/ArrowLeftRegular";
 import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
@@ -14,12 +15,17 @@ const Container = styled(FlexBox)`
   flex-direction: column;
 `;
 const Header = styled(FlexBox)`
-  display: flex;
-  flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  min-height: ${(p) => p.theme.space[15]}px;
+  padding: ${(p) => p.theme.space[12]}px;
+  padding-bottom: ${(p) => p.theme.space[10]}px;
 `;
+
+const Footer = styled(FlexBox)`
+  align-items: center;
+  padding: ${(p) => p.theme.space[8]}px ${(p) => p.theme.space[12]}px;
+`;
+
 const Wrapper = styled.div<{
   big?: boolean;
   width?: number;
@@ -29,7 +35,6 @@ const Wrapper = styled.div<{
   height: 100%;
   width: ${(p) =>
     p.big ? p.theme.sizes.drawer.side.big.width : p.theme.sizes.drawer.side.small.width}px;
-  padding: ${(p) => p.theme.space[6]}px ${(p) => p.theme.space[12]}px;
   background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
   display: flex;
   flex-direction: column;
@@ -51,6 +56,8 @@ const Overlay = styled.div`
 const ScrollWrapper = styled.div`
   overflow: scroll;
   position: relative;
+  padding: ${(p) => p.theme.space[12]}px;
+  padding-top: 0px;
   flex: 1;
 
   &::-webkit-scrollbar {
@@ -71,6 +78,7 @@ export interface DrawerProps {
   isOpen: boolean;
   children: React.ReactNode;
   title?: React.ReactNode;
+  footer?: React.ReactNode;
   big?: boolean;
   backgroundColor?: string;
   onClose: () => void;
@@ -83,6 +91,7 @@ const DrawerContent = ({
   isOpen,
   title,
   children,
+  footer,
   big,
   onClose,
   backgroundColor,
@@ -125,15 +134,23 @@ const DrawerContent = ({
                   </>
                 )}
                 {(
-                  <Text variant={"h5"} flexShrink={1}>
+                  <Text variant={"h3"} flex={1} textAlign="center">
                     {title}
                   </Text>
                 ) || <div />}
-                <Button onClick={onClose}>
-                  <Close />
-                </Button>
+                <FlexBox alignSelf="flex-start">
+                  <Button onClick={onClose}>
+                    <Close />
+                  </Button>
+                </FlexBox>
               </Header>
               <ScrollWrapper>{children}</ScrollWrapper>
+              {footer && (
+                <>
+                  <Divider variant="light" />
+                  <Footer>{footer}</Footer>
+                </>
+              )}
             </Container>
           </Wrapper>
         </TransitionSlide>

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -8,13 +8,10 @@ import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
 import Text from "../../asorted/Text";
 
-const Container = styled(FlexBox)<{
-  backgroundColor?: string;
-}>`
+const Container = styled(FlexBox)`
   width: 100%;
   height: 100%;
   flex-direction: column;
-  background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
 `;
 const Header = styled(FlexBox)`
   display: flex;

--- a/packages/react/src/components/layout/Drawer/index.tsx
+++ b/packages/react/src/components/layout/Drawer/index.tsx
@@ -8,10 +8,13 @@ import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
 import Text from "../../asorted/Text";
 
-const Container = styled(FlexBox)`
+const Container = styled(FlexBox)<{
+  backgroundColor?: string;
+}>`
   width: 100%;
   height: 100%;
   flex-direction: column;
+  background-color: ${(p) => p.backgroundColor ?? p.theme.colors.neutral.c00};
 `;
 const Header = styled(FlexBox)`
   display: flex;


### PR DESCRIPTION
Added the possibility of having a footer in the Drawer component and fixed a few spacing and sizing issues so it's more faithful to the Figma spec.
![drawer-footer](https://user-images.githubusercontent.com/6013294/145594337-2200413b-0c83-4f45-8125-9a4f73bc36c5.gif)

