### PR TITLE
React - Stepper - Add possibility for label to be a ReactNode

### DIFF
--- a/packages/react/src/components/navigation/progress/Stepper/ProgressSteps.stories.tsx
+++ b/packages/react/src/components/navigation/progress/Stepper/ProgressSteps.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ProgressSteps, { Props } from "./index";
+import ProgressSteps, { Props, StepText, StepState } from "./index";
 
 export default {
   title: "Navigation/Progress/Stepper",
@@ -16,7 +16,18 @@ export default {
 
 export const Component = (args: Props): JSX.Element => <ProgressSteps {...args} />;
 Component.args = {
-  steps: ["Crypto Asset", "Device", "Accounts", "Confirmation"],
+  steps: [
+    "Crypto Asset",
+    "Device",
+    ({ state }: { state: StepState }) => (
+      <StepText variant="small" state={state} textAlign="center">
+        Accounts
+        <br />
+        (step state: {state})
+      </StepText>
+    ),
+    "Confirmation",
+  ],
   activeIndex: 1,
   errored: false,
 };

--- a/packages/react/src/components/navigation/progress/Stepper/index.tsx
+++ b/packages/react/src/components/navigation/progress/Stepper/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactNode } from "react";
+import React, { memo } from "react";
 import styled from "styled-components";
 import { border, BorderProps, color, ColorProps, space, SpaceProps } from "styled-system";
 import CheckAlone from "@ledgerhq/icons-ui/react/CheckAloneMedium";
@@ -6,12 +6,23 @@ import CloseMedium from "@ledgerhq/icons-ui/react/CloseMedium";
 import Text from "../../../asorted/Text";
 import Flex from "../../../layout/Flex";
 
-type Label = string | ReactNode;
+/**
+ * The state of a progress bar step.
+ */
+export type StepState = "pending" | "current" | "completed" | "errored";
+
+type LabelType =
+  | string
+  | React.ComponentType<{ state: StepState }>
+  | ((props: { state: StepState }) => JSX.Element);
 export interface Props {
   /**
    * An array of labels that will determine the progress bar steps.
+   *  A label is either a string or a component that will be rendered with the
+   *  prop `state: "pending" | "current" | "completed" | "errored"`.
+   *  A styled StepText component is exported to allow easy styling of such a custom label.
    */
-  steps: Label[];
+  steps: LabelType[];
   /**
    * Index of the active step, starting at zero and defaulting to 0 if omitted.
    */
@@ -21,19 +32,18 @@ export interface Props {
    */
   errored?: boolean;
 }
-/**
- * The state of a progress bar step.
- */
-type StepState = "pending" | "current" | "completed" | "errored";
+
 export type StepProps = {
   /**
    * State of the step.
    */
   state: StepState;
   /**
-   * The label to display.
+   * The label to display. To display more than text, this can be a component that will be rendered with the
+   *  prop `state: "pending" | "current" | "completed" | "errored"`.
+   *  A styled StepText component is exported to allow easy styling of such a custom Label
    */
-  label: Label;
+  label: LabelType;
   /**
    * If true, hides the left "separator" bar that bridges the gap between the wider separator and the item.
    */
@@ -82,12 +92,12 @@ export const Item = {
   Errored: (): JSX.Element => <CloseMedium size={16} />,
 };
 
-const StepText = styled(Text)<{ inactive?: boolean; errored?: boolean }>`
+export const StepText = styled(Text)<{ state: StepState }>`
   color: ${(p) => {
-    if (p.errored) {
+    if (p.state === "errored") {
       return p.theme.colors.error.c100;
     }
-    if (p.inactive) {
+    if (p.state === "pending") {
       return p.theme.colors.neutral.c70;
     }
     return p.theme.colors.neutral.c100;
@@ -133,13 +143,12 @@ const stepContentsByState = {
 
 export const Step = memo(function Step({
   state,
-  label,
-  hideLeftSeparator,
+  label: Label,
+  hideLeftSeparator = true,
   nextState,
 }: StepProps): JSX.Element {
   const inactive = state === "pending";
-  const nextInactive = nextState === "pending";
-  const errored = state === "errored";
+  const nextInactive = state === "pending";
 
   return (
     <Flex flexDirection="column" alignItems="center">
@@ -152,12 +161,12 @@ export const Step = memo(function Step({
           <Flex flex="1" />
         )}
       </Item.Spacer>
-      {typeof label === "string" ? (
-        <StepText inactive={inactive} errored={errored} variant="small">
-          {label}
+      {typeof Label === "string" ? (
+        <StepText state={state} variant="small">
+          {Label}
         </StepText>
       ) : (
-        label
+        <Label state={state} />
       )}
     </Flex>
   );

--- a/packages/react/src/components/navigation/progress/Stepper/index.tsx
+++ b/packages/react/src/components/navigation/progress/Stepper/index.tsx
@@ -11,10 +11,7 @@ import Flex from "../../../layout/Flex";
  */
 export type StepState = "pending" | "current" | "completed" | "errored";
 
-type LabelType =
-  | string
-  | React.ComponentType<{ state: StepState }>
-  | ((props: { state: StepState }) => JSX.Element);
+type LabelType = string | React.ComponentType<{ state: StepState }>;
 export interface Props {
   /**
    * An array of labels that will determine the progress bar steps.
@@ -144,7 +141,7 @@ const stepContentsByState = {
 export const Step = memo(function Step({
   state,
   label: Label,
-  hideLeftSeparator = true,
+  hideLeftSeparator,
   nextState,
 }: StepProps): JSX.Element {
   const inactive = state === "pending";

--- a/packages/react/src/components/navigation/progress/Stepper/index.tsx
+++ b/packages/react/src/components/navigation/progress/Stepper/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, ReactNode } from "react";
 import styled from "styled-components";
 import { border, BorderProps, color, ColorProps, space, SpaceProps } from "styled-system";
 import CheckAlone from "@ledgerhq/icons-ui/react/CheckAloneMedium";
@@ -6,11 +6,12 @@ import CloseMedium from "@ledgerhq/icons-ui/react/CloseMedium";
 import Text from "../../../asorted/Text";
 import Flex from "../../../layout/Flex";
 
+type Label = string | ReactNode;
 export interface Props {
   /**
    * An array of labels that will determine the progress bar steps.
    */
-  steps: string[];
+  steps: Label[];
   /**
    * Index of the active step, starting at zero and defaulting to 0 if omitted.
    */
@@ -32,7 +33,7 @@ export type StepProps = {
   /**
    * The label to display.
    */
-  label: string;
+  label: Label;
   /**
    * If true, hides the left "separator" bar that bridges the gap between the wider separator and the item.
    */
@@ -151,9 +152,13 @@ export const Step = memo(function Step({
           <Flex flex="1" />
         )}
       </Item.Spacer>
-      <StepText inactive={inactive} errored={errored} variant="small">
-        {label}
-      </StepText>
+      {typeof label === "string" ? (
+        <StepText inactive={inactive} errored={errored} variant="small">
+          {label}
+        </StepText>
+      ) : (
+        label
+      )}
     </Flex>
   );
 });


### PR DESCRIPTION
On LLD the Stepper implementation currently accepts a ReactNode for the `label` prop.
This non breaking change makes it easier to use this lib's Stepper in LLD.