### PR TITLE
Native - Fix storybook "CenterView" width -> 100%

### DIFF
--- a/packages/native/storybook/stories/CenterView/index.tsx
+++ b/packages/native/storybook/stories/CenterView/index.tsx
@@ -6,6 +6,7 @@ import { StyleProvider } from "../../../src/styles/StyleProvider";
 
 export const Main = styled.View`
   flex: 1;
+  width: 100%;
   justify-content: center;
   align-items: center;
   background-color: ${(p) => p.theme.colors.background.main};

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -7,7 +7,6 @@ import "./Layout/Modal/Tooltip.stories";
 import "./Layout/ScrollContainer.stories";
 import "./Layout/Flex.stories";
 import "./Layout/Box.stories";
-import "./Layout/Notification.stories";
 import "./message/Notification/Notification.stories";
 import "./Navigation/SlideIndicator/SlideIndicator.stories";
 import "./Navigation/Stepper/Stepper.stories";


### PR DESCRIPTION
The view wrapping all stories now uses 100% of the screen width instead of being 
This issue was only visible in expo I believe, not in the web storybook.

In the following screenshots you can see in dark mode that the view wrapping the story would be the width of its content. It is now 100% of the window width.

PS:
**I also fixed a bad import that prevented metro bundler to compile. (The file for the Notification.stories has been moved)**

![before](https://user-images.githubusercontent.com/91890529/146579054-75931363-6386-4fc1-bfb3-69acacbcd012.jpg)
![after](https://user-images.githubusercontent.com/91890529/146579060-9e9affcc-6e59-4759-96b4-3817a6f9b0ad.jpg)