### PR TITLE
Native - BoxedIcon component

### DIFF
--- a/packages/native/src/components/Icon/BoxedIcon.tsx
+++ b/packages/native/src/components/Icon/BoxedIcon.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import styled from "styled-components/native";
+import Flex from "../Layout/Flex";
+
+export const DEFAULT_BOX_SIZE = 40;
+export const DEFAULT_ICON_SIZE = 16;
+export const DEFAULT_BADGE_SIZE = 20;
+
+// const getTopRightSquareClippedPolygon = (
+//   boxSize: number,
+//   rectangleSize: number
+// ) => {
+//   // clipping path that hides top right square of size `${rectangleSize}px`
+//   const diff = boxSize - rectangleSize;
+//   return `polygon(0 0, 0 0, 0 0, ${diff}px 0, ${diff}px ${rectangleSize}px, 100% ${rectangleSize}px, 100% 100%, 100% 100%, 100% 100%, 0 100%, 0 100%, 0 100%)`;
+// };
+
+const Container = styled(Flex).attrs((p: { size: number }) => ({
+  heigth: p.size,
+  width: p.size,
+  alignItems: "center",
+  justifyContent: "center",
+  position: "relative",
+  overflow: "visible",
+}))<{ size: number }>``;
+
+const IconBoxBackground = styled(Flex)<{ size: number; hasBadge: boolean }>`
+  position: absolute;
+  height: ${(p) => p.size}px;
+  width: ${(p) => p.size}px;
+  border-radius: ${(p) => p.theme.radii[2]}px;
+`;
+
+const BadgeContainer = styled.View<{ badgeSize: number }>`
+  position: absolute;
+  overflow: visible;
+  ${(p) => `
+    top: -${p.badgeSize / 2 - 2}px;
+    right: -${p.badgeSize / 2 - 2}px;
+    height: ${p.badgeSize}px;
+    width: ${p.badgeSize}px;`}
+`;
+
+export type IconProps = {
+  size?: number;
+  color?: string;
+};
+
+export type IconBoxProps = {
+  /**
+   * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `badgeSize` or a default size.
+   */
+  Badge?: React.ComponentType<IconProps>;
+  /**
+   * Color of the border
+   */
+  borderColor?: string;
+  /**
+   * Badge color, will be applied to the component provided in the `Badge` prop
+   */
+  badgeColor?: string;
+  /**
+   * Badge size, will be applied to the component provided in the `Badge` prop
+   */
+  badgeSize?: number;
+  children?: JSX.Element;
+  /**
+   * Box size for preview
+   */
+  size?: number;
+};
+
+export type BoxedIconProps = IconBoxProps & {
+  /**
+   * Component that takes `{size?: number; color?: string}` as props. Will be rendered at the top right with the size provided in `iconSize` or a default size.
+   */
+  Icon: React.ComponentType<IconProps> | ((props: IconProps) => JSX.Element);
+  /**
+   * Icon size, will be applied to the component provided in the `Icon` prop
+   */
+  iconSize?: number;
+  /**
+   * Icon color, will be applied to the component provided in the `Icon` prop
+   */
+  iconColor?: string;
+};
+
+export const IconBox = ({
+  Badge,
+  size = DEFAULT_BOX_SIZE,
+  children,
+  borderColor = "neutral.c40",
+  badgeColor,
+  badgeSize = DEFAULT_BADGE_SIZE,
+}: IconBoxProps) => {
+  const hasBadge = !!Badge;
+  return (
+    <Container size={size}>
+      <IconBoxBackground
+        size={size}
+        hasBadge={hasBadge}
+        border="1px solid"
+        borderColor={borderColor}
+      />
+      {children}
+      {hasBadge && (
+        <BadgeContainer badgeSize={badgeSize}>
+          <Badge size={badgeSize} color={badgeColor} />
+        </BadgeContainer>
+      )}
+    </Container>
+  );
+};
+
+const BoxedIcon = ({
+  Icon,
+  iconSize = DEFAULT_ICON_SIZE,
+  iconColor,
+  ...iconBoxProps
+}: BoxedIconProps) => {
+  return (
+    <IconBox {...iconBoxProps}>
+      <Icon size={iconSize || DEFAULT_ICON_SIZE} color={iconColor} />
+    </IconBox>
+  );
+};
+
+export default BoxedIcon;

--- a/packages/native/src/components/Icon/index.ts
+++ b/packages/native/src/components/Icon/index.ts
@@ -1,1 +1,2 @@
 export { default as IconBox } from "./IconBox";
+export { default as BoxedIcon } from "./BoxedIcon";

--- a/packages/native/storybook/stories/CenterView/index.tsx
+++ b/packages/native/storybook/stories/CenterView/index.tsx
@@ -6,6 +6,7 @@ import { StyleProvider } from "../../../src/styles/StyleProvider";
 
 export const Main = styled.View`
   flex: 1;
+  width: 100%;
   justify-content: center;
   align-items: center;
   background-color: ${(p) => p.theme.colors.background.main};

--- a/packages/native/storybook/stories/Icon/BoxedIcon.stories.tsx
+++ b/packages/native/storybook/stories/Icon/BoxedIcon.stories.tsx
@@ -1,0 +1,35 @@
+import { storiesOf } from "../storiesOf";
+import React from "react";
+import Flex from "../../../src/components/Layout/Flex";
+import Box from "../../../src/components/Layout/Box";
+import { Icons } from "../../../src/assets";
+import BoxedIcon from "../../../src/components/Icon/BoxedIcon";
+
+const BoxedIconStory = () => (
+  <Flex flexDirection="column">
+    <BoxedIcon Icon={Icons.HandshakeMedium} />
+    <Box height={20} />
+    <BoxedIcon
+      Icon={Icons.HandshakeMedium}
+      Badge={Icons.CircledCheckSolidMedium}
+      badgeColor="success.c100"
+    />
+    <Box height={20} />
+    <BoxedIcon
+      Icon={Icons.HandshakeMedium}
+      Badge={Icons.CircledCrossSolidMedium}
+      iconColor="error.c100"
+      borderColor="error.c40"
+      badgeColor="error.c100"
+    />
+    <Box height={20} />
+    <BoxedIcon
+      Icon={Icons.HandshakeMedium}
+      Badge={Icons.ClockSolidMedium}
+      iconColor="neutral.c50"
+      badgeColor="neutral.c70"
+    />
+  </Flex>
+);
+
+storiesOf((story) => story("Icon", module).add("BoxedIcon", BoxedIconStory));

--- a/packages/native/storybook/stories/Icon/BoxedIcon.stories.tsx
+++ b/packages/native/storybook/stories/Icon/BoxedIcon.stories.tsx
@@ -6,12 +6,14 @@ import { Icons } from "../../../src/assets";
 import BoxedIcon from "../../../src/components/Icon/BoxedIcon";
 
 const BoxedIconStory = () => (
-  <Flex flexDirection="column">
+  <Flex flexDirection="column" alignItems="center">
     <BoxedIcon Icon={Icons.HandshakeMedium} />
     <Box height={20} />
     <BoxedIcon
       Icon={Icons.HandshakeMedium}
       Badge={Icons.CircledCheckSolidMedium}
+      iconColor="success.c100"
+      borderColor="success.c40"
       badgeColor="success.c100"
     />
     <Box height={20} />

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -10,6 +10,7 @@ import "./Layout/Box.stories";
 import "./message/Notification/Notification.stories";
 import "./Navigation/SlideIndicator/SlideIndicator.stories";
 import "./Navigation/Stepper/Stepper.stories";
+import "./Icon/BoxedIcon.stories";
 import "./Icon/IconBox.stories";
 import "./Icon/AssetsIcons.stories";
 import "./Loader/Loader.stories";

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -7,7 +7,6 @@ import "./Layout/Modal/Tooltip.stories";
 import "./Layout/ScrollContainer.stories";
 import "./Layout/Flex.stories";
 import "./Layout/Box.stories";
-import "./Layout/Notification.stories";
 import "./message/Notification/Notification.stories";
 import "./Navigation/SlideIndicator/SlideIndicator.stories";
 import "./Navigation/Stepper/Stepper.stories";

--- a/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
+++ b/packages/react/src/components/asorted/Icon/BoxedIcon.tsx
@@ -6,6 +6,10 @@ export const DEFAULT_BOX_SIZE = 40;
 export const DEFAULT_ICON_SIZE = 16;
 export const DEFAULT_BADGE_SIZE = 20;
 
+function getClipRectangleSize(badgeSize: number): number {
+  return (3 / 4) * badgeSize;
+}
+
 const getTopRightSquareClippedPolygon = (boxSize: number, rectangleSize: number) => {
   // clipping path that hides top right square of size `${rectangleSize}px`
   const diff = boxSize - rectangleSize;
@@ -20,12 +24,15 @@ const Container = styled(Flex).attrs((p: { size: number }) => ({
   position: "relative",
 }))<{ size: number }>``;
 
-const IconBoxBackground = styled(Flex)<{ size: number; hasBadge: boolean }>`
+const IconBoxBackground = styled(Flex)<{ size: number; badgeSize: number; hasBadge: boolean }>`
   position: absolute;
   height: ${(p) => p.size}px;
   width: ${(p) => p.size}px;
   ${(p) => {
-    return p.hasBadge && `clip-path: ${getTopRightSquareClippedPolygon(p.size, 15)};`;
+    return (
+      p.hasBadge &&
+      `clip-path: ${getTopRightSquareClippedPolygon(p.size, getClipRectangleSize(p.badgeSize))};`
+    );
   }};
   border-radius: ${(p) => p.theme.radii[2]}px;
 `;
@@ -94,6 +101,7 @@ export const IconBox = ({
     <Container size={size}>
       <IconBoxBackground
         size={size}
+        badgeSize={badgeSize}
         hasBadge={hasBadge}
         border="1px solid"
         borderColor={borderColor}


### PR DESCRIPTION
Same component as on the React/web side.

Component that wraps an `Icon` component (passed as props) in a styled box with an optional `Badge` component (passed as props).

In storybook -> Icon/BoxedIcon 

[Figma for reference](https://www.figma.com/file/WXCEmRMwW47ELrFonzPTGg/LLD-%2F-Library?node-id=5136%3A32649)

⚠️ In order to draw the clipped border when there is a badge, I'm actually using react-native-svg, this might potentially be bad for perf ... Other simpler & more performant solution would be to draw a square behind the badge with the same color as the background but 🤮

<img width="177" alt="Screenshot 2021-12-17 at 20 09 28" src="https://user-images.githubusercontent.com/91890529/146596645-a98d4aa0-223c-422c-aa97-6dfc1fcbf300.png">

