### PR TITLE
Native - Add uppercase & textTransform styled system + h1..4, subtitle in Uppercase

### DIFF
--- a/packages/native/src/components/Text/getTextStyle.ts
+++ b/packages/native/src/components/Text/getTextStyle.ts
@@ -9,6 +9,7 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
     fontFamily: string;
     lineHeight?: number;
     paddingTop?: number;
+    textTransform?: string;
   }
 > {
   return {
@@ -16,19 +17,23 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
       fontFamily: "Alpha",
       lineHeight: 32,
       paddingTop: bracket ? 15 : 0,
+      textTransform: "uppercase",
     },
     h2: {
       fontFamily: "Alpha",
       lineHeight: 28,
       paddingTop: bracket ? 10 : 0,
+      textTransform: "uppercase",
     },
     h3: {
       fontFamily: "Alpha",
       lineHeight: 20,
       paddingTop: bracket ? 5 : 0,
+      textTransform: "uppercase",
     },
     h4: {
       fontFamily: "Inter",
+      textTransform: "uppercase",
     },
     large: {
       fontFamily: "Inter",
@@ -52,6 +57,7 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
     },
     subtitle: {
       fontFamily: "Inter",
+      textTransform: "uppercase",
     },
     tiny: {
       fontFamily: "Inter",

--- a/packages/native/src/components/Text/index.tsx
+++ b/packages/native/src/components/Text/index.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { TextProps } from "react-native";
 import styled, { useTheme } from "styled-components/native";
 import {
+  compose,
   fontSize,
   FontSizeProps,
   textAlign,
   TextAlignProps,
   lineHeight,
   LineHeightProps,
+  system,
 } from "styled-system";
 import baseStyled, { BaseStyledProps } from "../styled";
 
@@ -16,6 +18,19 @@ import BracketLeft from "../../icons/BracketRight";
 import { getColor } from "../../styles";
 import { FontWeightTypes, getTextStyle } from "./getTextStyle";
 import { TextVariants } from "../../styles/theme";
+
+const uppercase = system({
+  uppercase: {
+    property: "textTransform",
+    transform: (value) => (value ? "uppercase" : "none"),
+  },
+});
+
+const textTransform = system({
+  textTransform: {
+    property: "textTransform",
+  },
+});
 
 export interface BaseTextProps
   extends TextProps,
@@ -30,6 +45,8 @@ export interface BaseTextProps
   color?: string;
   lineHeight?: number;
   bracket?: boolean;
+  textTransform?: string;
+  uppercase?: boolean;
   children: React.ReactNode;
 }
 
@@ -38,9 +55,7 @@ const Base = baseStyled.Text.attrs((p: BaseTextProps) => ({
   color: p.color || "neutral.c100",
 }))<BaseTextProps>`
   ${(p) => getTextStyle(p)}
-  ${lineHeight};
-  ${fontSize};
-  ${textAlign};
+  ${compose(lineHeight, fontSize, textAlign, uppercase, textTransform)}
   justify-content: center;
   align-items: center;
 `;

--- a/packages/native/src/components/Text/index.tsx
+++ b/packages/native/src/components/Text/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TextProps } from "react-native";
+import { TextProps, TextStyle } from "react-native";
 import styled, { useTheme } from "styled-components/native";
 import {
   compose,
@@ -45,7 +45,7 @@ export interface BaseTextProps
   color?: string;
   lineHeight?: number;
   bracket?: boolean;
-  textTransform?: string;
+  textTransform?: TextStyle["textTransform"];
   uppercase?: boolean;
   children: React.ReactNode;
 }

--- a/packages/native/storybook/stories/Text/Text.stories.tsx
+++ b/packages/native/storybook/stories/Text/Text.stories.tsx
@@ -5,7 +5,7 @@ import { select, boolean } from "@storybook/addon-knobs";
 import Text from "../../../src/components/Text";
 
 storiesOf((story) =>
-  story("Text", module).add("regular", () => (
+  story("Text", module).add("Text", () => (
     <Text
       variant={select(
         "variant",

--- a/packages/native/storybook/stories/Text/TextOverview.stories.tsx
+++ b/packages/native/storybook/stories/Text/TextOverview.stories.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { ScrollView } from "react-native";
+import { FontWeightTypes } from "src/components/Text/getTextStyle";
+import { Flex } from "../../../src/components/Layout";
+import Text from "../../../src/components/Text";
+import { TextVariants } from "../../../src/styles/theme";
+import { storiesOf } from "../storiesOf";
+
+const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4"];
+
+const mainVariants: TextVariants[] = [
+  "large",
+  "body",
+  "bodyLineHeight",
+  "paragraph",
+  "paragraphLineHeight",
+  "small",
+  "tiny",
+];
+
+const subtitleVariants: TextVariants[] = ["subtitle"];
+
+const variants: TextVariants[] = [
+  ...headerVariants,
+  ...mainVariants,
+  ...subtitleVariants,
+];
+
+const makeIsInCategory =
+  (variantsArray: TextVariants[]) => (variant: TextVariants) =>
+    variantsArray.includes(variant);
+const isHeader = makeIsInCategory(headerVariants);
+const isSubtitle = makeIsInCategory(subtitleVariants);
+
+const mainFontWeights: FontWeightTypes[] = ["medium", "semiBold", "bold"];
+
+const Overview = () => {
+  return (
+    <ScrollView horizontal contentContainerStyle={{ padding: 20 }}>
+      <ScrollView>
+        <Flex flexDirection="column">
+          {variants.map((variant) => {
+            const fontWeightsToShow: FontWeightTypes[] = isHeader(variant)
+              ? ["medium"]
+              : isSubtitle(variant)
+              ? ["semiBold"]
+              : mainFontWeights;
+            const decorationsToShow: ("none" | "underline")[] =
+              isHeader(variant) || isSubtitle(variant)
+                ? ["none"]
+                : ["none", "underline"];
+            return (
+              <Flex flexDirection="row" mb={8}>
+                <div style={{ minWidth: 250 }}>
+                  <Text variant="small" color="neutral.c90">
+                    variant="{variant}"
+                  </Text>
+                  <br />
+                  <Text variant="tiny" color="neutral.c70">
+                    fontWeights: {JSON.stringify(fontWeightsToShow)}
+                  </Text>
+                </div>
+                {fontWeightsToShow.flatMap((fontWeight) =>
+                  decorationsToShow.map((textDecorationLine) => (
+                    <Flex maxWidth={270} mx={4}>
+                      <Text
+                        variant={variant}
+                        fontWeight={fontWeight}
+                        style={{ textDecorationLine }}
+                      >
+                        Lend stablecoins to the Compound protocol...
+                      </Text>
+                    </Flex>
+                  ))
+                )}
+              </Flex>
+            );
+          })}
+        </Flex>
+      </ScrollView>
+    </ScrollView>
+  );
+};
+
+storiesOf((story) => story("Text", module).add("Overview", Overview));

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -1,5 +1,6 @@
 import "./Button/Button.stories";
 import "./Text/Text.stories";
+import "./Text/TextOverview.stories";
 import "./Layout/Modal/Modal.stories";
 import "./Layout/Modal/BottomDrawer.stories";
 import "./Layout/Modal/Popin.stories";


### PR DESCRIPTION
- Add styled system to base `Text` component to support `textTransform?: string` and `uppercase?: boolean` props.
- Add uppercase by default to `h1` to `h4` and `subtitle` variants.
- Add "Text Overview" story (similar to the one on the React side)

<img width="956" alt="Screenshot 2021-12-20 at 15 37 42" src="https://user-images.githubusercontent.com/91890529/146784209-6d2d75c4-d49d-4020-a4ca-52ce4860cc73.png">

