### PR TITLE
fix: avoid text overflow in row mode

### DIFF
--- a/packages/native/src/components/Form/Switch/index.tsx
+++ b/packages/native/src/components/Form/Switch/index.tsx
@@ -36,7 +36,7 @@ const Switch = ({
         <Text
           variant="body"
           color={checked ? colors.primary.c90 : colors.neutral.c100}
-          style={{ marginLeft: space[3] }}
+          style={{ marginLeft: space[3], flexShrink: 1 }}
         >
           {label}
         </Text>

--- a/packages/native/src/components/Layout/List/List/index.tsx
+++ b/packages/native/src/components/Layout/List/List/index.tsx
@@ -28,9 +28,14 @@ export const ListItem = ({
           {bullet}
         </Box>
       )}
-      <Flex flexDirection={"column"}>
+      <Flex flexDirection={"column"} flexShrink={1}>
         {title && (
-          <Text variant={"body"} fontWeight={"semiBold"} color={"neutral.c100"}>
+          <Text
+            variant={"body"}
+            fontWeight={"semiBold"}
+            color={"neutral.c100"}
+            mb={description ? 2 : null}
+          >
             {title}
           </Text>
         )}


### PR DESCRIPTION
Yop,
This is a style issue we potentially have elsewhere but for the moment I only caught it when dealing with Switch/List components.

**Before**
![Simulator Screen Shot - iPhone 13 - 2021-12-20 at 16 50 32](https://user-images.githubusercontent.com/33158502/146808734-90e115e6-a36b-4edd-aaea-0b72baecb45e.png)

**After**
![Simulator Screen Shot - iPhone 13 - 2021-12-20 at 16 50 36](https://user-images.githubusercontent.com/33158502/146808761-9c9f994c-dafc-4fa8-855d-ebe28b0c7f3f.png)
