### PR TITLE
Flow stepper can now have hidden steps

### DIFF
--- a/packages/react/src/components/navigation/FlowStepper/FlowStepper.stories.tsx
+++ b/packages/react/src/components/navigation/FlowStepper/FlowStepper.stories.tsx
@@ -118,14 +118,14 @@ export const Minimal: StoryTemplate<FlowStepperProps<unknown>> = (args) => {
               variant="main"
               outline
               disabled={activeIndex <= 0}
-              onClick={() => updateArgs({ activeIndex: activeIndex - 1 })}
+              onClick={() => updateArgs({ activeIndex: Math.floor(activeIndex) - 1 })}
             >
               Previous
             </Button>
             <Button
               variant="main"
               disabled={activeIndex >= NB_OF_STEPS - 1}
-              onClick={() => updateArgs({ activeIndex: activeIndex + 1 })}
+              onClick={() => updateArgs({ activeIndex: Math.floor(activeIndex) + 1 })}
             >
               Continue
             </Button>
@@ -134,13 +134,23 @@ export const Minimal: StoryTemplate<FlowStepperProps<unknown>> = (args) => {
       )}
       {...rest}
     >
-      {new Array(NB_OF_STEPS).fill(0).map((_, index) => (
-        <FlowStepper.Step label={"Step " + index}>
-          <Text key={index} variant="body">
-            {lipsum}
+      {[
+        ...new Array(NB_OF_STEPS).fill(0).map((_, index) => (
+          <FlowStepper.Step label={"Step " + index}>
+            <Text key={index} variant="body">
+              {lipsum}
+            </Text>
+            <Button mt={2} onClick={() => updateArgs({ activeIndex: 1.5 })}>
+              Navigate to the hidden step.
+            </Button>
+          </FlowStepper.Step>
+        )),
+        <FlowStepper.Step label="Hidden Step" index={1.5}>
+          <Text key="hidden" variant="body">
+            I am hidden.
           </Text>
-        </FlowStepper.Step>
-      ))}
+        </FlowStepper.Step>,
+      ]}
     </FlowStepper>
   );
 };

--- a/packages/react/src/components/navigation/FlowStepper/FlowStepper.stories.tsx
+++ b/packages/react/src/components/navigation/FlowStepper/FlowStepper.stories.tsx
@@ -118,14 +118,14 @@ export const Minimal: StoryTemplate<FlowStepperProps<unknown>> = (args) => {
               variant="main"
               outline
               disabled={activeIndex <= 0}
-              onClick={() => updateArgs({ activeIndex: Math.floor(activeIndex) - 1 })}
+              onClick={() => updateArgs({ activeIndex: activeIndex - 1 })}
             >
               Previous
             </Button>
             <Button
               variant="main"
               disabled={activeIndex >= NB_OF_STEPS - 1}
-              onClick={() => updateArgs({ activeIndex: Math.floor(activeIndex) + 1 })}
+              onClick={() => updateArgs({ activeIndex: activeIndex + 1 })}
             >
               Continue
             </Button>
@@ -140,12 +140,12 @@ export const Minimal: StoryTemplate<FlowStepperProps<unknown>> = (args) => {
             <Text key={index} variant="body">
               {lipsum}
             </Text>
-            <Button mt={2} onClick={() => updateArgs({ activeIndex: 1.5 })}>
+            <Button mt={2} onClick={() => updateArgs({ activeIndex: NB_OF_STEPS })}>
               Navigate to the hidden step.
             </Button>
           </FlowStepper.Step>
         )),
-        <FlowStepper.Step label="Hidden Step" index={1.5}>
+        <FlowStepper.Step label="Hidden Step" hidden>
           <Text key="hidden" variant="body">
             I am hidden.
           </Text>

--- a/packages/react/src/components/navigation/FlowStepper/index.tsx
+++ b/packages/react/src/components/navigation/FlowStepper/index.tsx
@@ -9,9 +9,13 @@ export type StepProps = {
    */
   label: string;
   /**
-   * A specific index, useful if you want the step to be invisible by specifying negative or floating indexes.
+   * A specific index, can be used to explicitely order steps.
    */
   index?: number;
+  /**
+   * Hides the step from the progress stepper.
+   */
+  hidden?: boolean;
   /**
    * The step contents.
    */
@@ -87,8 +91,9 @@ function FlowStepper<ExtraProps>({
     (acc, child, idx) => {
       const index = (isElement(child) && child.props.index) ?? idx;
       const label = isElement(child) && child.props.label;
+      const hidden = isElement(child) && child.props.hidden;
 
-      if (label) {
+      if (label && !hidden) {
         acc.steps[index] = label;
       }
       if (index === activeIndex) {


### PR DESCRIPTION
#### Allows passing explicit step indexes - which can be used to make steps "invisible" in the progress stepper.

<img width="761" alt="Capture d’écran 2021-12-22 à 10 48 09" src="https://user-images.githubusercontent.com/3428394/147072863-c3c55d66-4c5c-45ee-9c31-ef1b3d72ff3d.png">

