### PR TITLE
LL-8804 Add possibility of using an icon name for icon buttons

### DIFF
--- a/packages/native/src/components/Icon/Icon.tsx
+++ b/packages/native/src/components/Icon/Icon.tsx
@@ -1,0 +1,36 @@
+import * as icons from "@ledgerhq/icons-ui/react";
+import React from "react";
+
+export type Props = {
+  name: string;
+  size?: number;
+  weight?: "Regular" | "Thin" | "Light" | "Medium" | "UltraLight";
+  color?: string;
+};
+
+export const iconNames = Array.from(
+  Object.keys(icons).reduce((set, rawKey) => {
+    const key = rawKey
+      .replace(/(.+)(Regular|Light|UltraLight|Thin|Medium)+$/g, "$1")
+      .replace(/(.+)(Ultra)+$/g, "$1");
+    if (!set.has(key)) set.add(key);
+    return set;
+  }, new Set<string>())
+);
+
+const Icon = ({
+  name,
+  size = 16,
+  color = "currentColor",
+  weight = "Medium",
+}: Props): JSX.Element | null => {
+  const maybeIconName = `${name}${weight}`;
+  if (maybeIconName in icons) {
+    // @ts-expect-error FIXME I don't know how to make you happy ts
+    const Component = icons[maybeIconName];
+    return <Component size={size} color={color} />;
+  }
+  return null;
+};
+
+export default Icon;

--- a/packages/native/src/components/Icon/index.ts
+++ b/packages/native/src/components/Icon/index.ts
@@ -1,2 +1,3 @@
 export { default as IconBox } from "./IconBox";
 export { default as BoxedIcon } from "./BoxedIcon";
+export { default as Icon } from "./Icon";

--- a/packages/native/src/components/cta/Button/index.tsx
+++ b/packages/native/src/components/cta/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useMemo } from "react";
 import styled, { useTheme } from "styled-components/native";
 
 import {
@@ -12,11 +12,13 @@ import {
 } from "../../cta/Button/getButtonStyle";
 import { ctaIconSize, ctaTextType } from "../../cta/getCtaStyle";
 import Text from "../../Text";
+import { Icon as IconComponent } from "../../Icon";
 import baseStyled, { BaseStyledProps } from "../../styled";
 
 export type ButtonProps = TouchableOpacityProps &
   BaseStyledProps & {
     Icon?: React.ComponentType<{ size: number; color: string }> | null;
+    iconName?: string;
     type?: "main" | "shade" | "error" | "color" | "default";
     size?: "small" | "medium" | "large";
     iconPosition?: "right" | "left";
@@ -96,9 +98,24 @@ const ButtonContainer = (
     children,
     hide = false,
     size = "medium",
+    iconName,
   } = props;
   const theme = useTheme();
   const { text } = getButtonColorStyle(theme.colors, props);
+
+  const IconNode = useMemo(
+    () =>
+      (iconName && (
+        <IconComponent
+          name={iconName}
+          size={ctaIconSize[size]}
+          color={text.color}
+        />
+      )) ||
+      (Icon && <Icon size={ctaIconSize[size]} color={text.color} />),
+    [iconName, size, Icon, text.color]
+  );
+
   return (
     <Container hide={hide}>
       {iconPosition === "right" && children ? (
@@ -110,11 +127,11 @@ const ButtonContainer = (
           {children}
         </Text>
       ) : null}
-      {Icon ? (
+      {IconNode && (
         <IconContainer iconButton={!children} iconPosition={iconPosition}>
-          <Icon size={ctaIconSize[size]} color={text.color} />
+          {IconNode}
         </IconContainer>
-      ) : null}
+      )}
       {iconPosition === "left" && children ? (
         <Text
           variant={ctaTextType[size]}

--- a/packages/native/storybook/stories/Button/Button.stories.tsx
+++ b/packages/native/storybook/stories/Button/Button.stories.tsx
@@ -1,6 +1,5 @@
-import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../storiesOf";
-import { select, boolean } from "@storybook/addon-knobs";
+import { select, boolean, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import React from "react";
 import Button, { PromisableButton } from "../../../src/components/cta/Button";
@@ -13,6 +12,7 @@ const iconOptions = {
   None: undefined,
 };
 const iconSelect = () => iconOptions[select("Icon", ["Info", "None"], "None")];
+const iconName = () => text("Icon Name", "Info");
 
 const Regular = (): JSX.Element => (
   <Button
@@ -24,6 +24,7 @@ const Regular = (): JSX.Element => (
     size={select("size", ["small", "medium", "large", undefined], undefined)}
     iconPosition={select("iconPosition", ["right", "left"], "right")}
     Icon={iconSelect()}
+    iconName={iconName()}
     disabled={boolean("disabled", false)}
     outline={boolean("outline", false)}
     onPress={action("onPress")}

--- a/packages/native/storybook/stories/Icon/AssetsIcons.stories.tsx
+++ b/packages/native/storybook/stories/Icon/AssetsIcons.stories.tsx
@@ -2,13 +2,14 @@ import { View } from "react-native";
 import { storiesOf } from "../storiesOf";
 import React from "react";
 import { Icons } from "../../../src/assets";
+import { Icon } from "../../../src/components/Icon";
 
 const IconSample = () => (
   <View>
     <Icons.BedMedium color={"blue"} />
     <Icons.AppleMedium color={"blue"} />
-    <Icons.HelpRegular color={"blue"} />
-    <Icons.DevicesMedium color={"blue"} />
+    <Icon name="Help" weight="Regular" color={"blue"} />
+    <Icon name="Devices" color={"blue"} />
   </View>
 );
 

--- a/packages/react/src/components/cta/Button/index.tsx
+++ b/packages/react/src/components/cta/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import styled, { css, StyledProps } from "styled-components";
 import baseStyled, { BaseStyledProps } from "../../styled";
 import { fontSize, border, BordersProps, compose } from "styled-system";
@@ -6,6 +6,7 @@ import fontFamily from "../../../styles/styled/fontFamily";
 import { fontSizes } from "../../../styles/theme";
 import { rgba } from "../../../styles/helpers";
 import ChevronBottom from "@ledgerhq/icons-ui/react/ChevronBottomRegular";
+import IconComponent from "../../asorted/Icon";
 
 export type ButtonVariants = "main" | "shade" | "error" | "color";
 export type IconPosition = "right" | "left";
@@ -22,6 +23,7 @@ interface BaseProps extends BaseStyledProps, BordersProps {
 }
 
 export interface ButtonProps extends BaseProps, React.RefAttributes<HTMLButtonElement> {
+  iconName?: string;
   Icon?: React.ComponentType<{ size: number; color?: string }>;
   children?: React.ReactNode;
   onClick?: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
@@ -213,17 +215,29 @@ export const Base = baseStyled.button.attrs((p: BaseProps) => ({
 const ContentContainer = styled.div``;
 
 const Button = (
-  { Icon, iconPosition = "right", iconSize = 16, children, onClick, ...props }: ButtonProps,
+  {
+    Icon,
+    iconPosition = "right",
+    iconSize = 16,
+    children,
+    onClick,
+    iconName,
+    ...props
+  }: ButtonProps,
   ref?: React.ForwardedRef<HTMLButtonElement>,
 ): React.ReactElement => {
+  const iconNodeSize = iconSize || fontSizes[props.fontSize ?? 4];
+  const IconNode = useMemo(
+    () =>
+      (iconName && <IconComponent name={iconName} size={iconNodeSize} />) ||
+      (Icon && <Icon size={iconNodeSize} />),
+    [iconName, iconNodeSize, Icon],
+  );
+
   return (
     <Base {...props} ref={ref} iconButton={!(Icon == null) && !children} onClick={onClick}>
       {iconPosition === "right" ? <ContentContainer>{children}</ContentContainer> : null}
-      {Icon != null ? (
-        <IconContainer iconPosition={iconPosition}>
-          <Icon size={iconSize || fontSizes[props.fontSize ?? 4]} />
-        </IconContainer>
-      ) : null}
+      {IconNode && <IconContainer iconPosition={iconPosition}>{IconNode}</IconContainer>}
       {iconPosition === "left" ? <ContentContainer>{children}</ContentContainer> : null}
     </Base>
   );


### PR DESCRIPTION
This adds the possibility of passing an icon name instead of a React Node for Icon Button. If the name exists as one of the icons provided by the library, it will be automatically used. This way there's no need to manually import and render the icons if the icons being used are the ones provided by the lib.
![iconname-button-native](https://user-images.githubusercontent.com/6013294/147358876-d06a971b-1f28-44ea-8ae0-bb640df086f6.gif)

