### PR TITLE
Add back buttons' focus box-shadow

### DIFF
--- a/packages/react/src/components/cta/Button/index.tsx
+++ b/packages/react/src/components/cta/Button/index.tsx
@@ -169,6 +169,9 @@ export const Base = baseStyled.button.attrs((p: BaseProps) => ({
   &:active {
     box-shadow: 0 0 0 4px ${(p) => rgba(p.theme.colors.primary.c60, 0.4)};
   }
+  &:focus {
+    box-shadow: 0 0 0 2px ${(p) => rgba(p.theme.colors.primary.c60, 0.4)};
+  }
 
   ${(p) => {
     const variants = getVariantColors(p);


### PR DESCRIPTION
Add a small box-shadow effect for when a button is focused.

![image](https://user-images.githubusercontent.com/6013294/147487045-c8367b33-78de-4b9b-a498-48fbd5514e8e.png)
