### PR TITLE
React - Dropdown overflow behavior

### DIFF
--- a/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
@@ -96,6 +96,6 @@ export default {
     closeOnClickOutside: { type: "boolean", defaultValue: true },
     closeOnClickInside: { type: "boolean", defaultValue: false },
     disabled: { type: "boolean", defaultValue: false },
-    flipEnabled: { type: "boolean", defaultValue: true },
+    flipDisabled: { type: "boolean", defaultValue: false },
   },
 };

--- a/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
@@ -1,22 +1,37 @@
 import React from "react";
 import Flex from "../../layout/Flex";
+import Box from "../../layout/Box";
 import Text from "../../asorted/Text";
 import DropdownGenericComponent, { Props as DropdownGenericProps } from ".";
+import Divider from "../../asorted/Divider";
 
-const ChildrenExample = () => (
-  <Flex
-    height={200}
-    width={180}
-    padding={10}
-    backgroundColor="neutral.c30"
-    justifyContent="center"
-    alignItems="center"
-  >
+const SmallChild = () => (
+  <Flex padding={10} backgroundColor="neutral.c30" justifyContent="center" alignItems="center">
     <Text variant="small" color="palette.neutral.c60" textAlign="center">
       I'm a simple div with a grey background and no margin passed as children of the dropdown
       component
     </Text>
   </Flex>
+);
+
+const BigChild = () => (
+  <Box
+    padding={10}
+    flexDirection="column"
+    width="300px"
+    backgroundColor="neutral.c30"
+    justifyContent="center"
+    alignItems="center"
+  >
+    <Text maxWidth="200px" variant="small" color="palette.neutral.c60" textAlign="center">
+      If you put content that is bigger than the available space, the dropdown will have a maxHeight
+      and its inner container will scroll
+    </Text>
+    <Box height="100px" width="100px" backgroundColor="lightgreen" />
+    <Box height="120px" width="100px" backgroundColor="lightcoral" />
+    <Box height="200px" width="100px" backgroundColor="lightblue" />
+    <Box height="120px" width="100px" backgroundColor="lightcoral" />
+  </Box>
 );
 
 const BottomPlaceholder = () => (
@@ -36,13 +51,16 @@ const BottomPlaceholder = () => (
 );
 
 const DropdownStoryTemplate = (
-  props: Omit<DropdownGenericProps, "children"> & { containerProps: Record<string, unknown> },
+  props: Omit<DropdownGenericProps, "children"> & {
+    big?: boolean;
+    containerProps: Record<string, unknown>;
+  },
 ) => {
-  const { containerProps = {}, ...rest } = props;
+  const { containerProps = {}, big = false, ...rest } = props;
   return (
     <Flex flexDirection="column" {...containerProps}>
       <DropdownGenericComponent {...rest}>
-        <ChildrenExample />
+        {big ? <BigChild /> : <SmallChild />}
       </DropdownGenericComponent>
       <BottomPlaceholder />
     </Flex>
@@ -56,12 +74,15 @@ export const DropdownGeneric = (args: DropdownGenericProps): React.ReactNode => 
        * Calling DropdownTemplate as a function here to trick storybook into displaying
        * the actual code in "show code" instead of an opaque "DropdownTemplate" component
        *  */}
+      <Text variant="h3">Small content:</Text>
       {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-start" } })}
       {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "center" } })}
       {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-end" } })}
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-start" } })}
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "center" } })}
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-end" } })}
+      <Divider variant="light" />
+      <Text variant="h3">Big content:</Text>
+      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "flex-start" } })}
+      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "center" } })}
+      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "flex-end" } })}
     </Flex>
   );
 };
@@ -75,5 +96,6 @@ export default {
     closeOnClickOutside: { type: "boolean", defaultValue: true },
     closeOnClickInside: { type: "boolean", defaultValue: false },
     disabled: { type: "boolean", defaultValue: false },
+    flipEnabled: { type: "boolean", defaultValue: true },
   },
 };

--- a/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Flex from "../../layout/Flex";
 import Box from "../../layout/Box";
 import Text from "../../asorted/Text";
+import Alert from "../../message/Alert";
 import DropdownGenericComponent, { Props as DropdownGenericProps } from ".";
 import Divider from "../../asorted/Divider";
 
@@ -14,7 +15,7 @@ const SmallChild = () => (
     justifyContent="center"
     alignItems="center"
   >
-    <Text variant="small" color="palette.neutral.c60" textAlign="center">
+    <Text variant="small" color="neutral.c60" textAlign="center">
       I'm a simple div with a grey background and no margin passed as children of the dropdown
       component.
     </Text>
@@ -26,19 +27,19 @@ const BigChild = ({ containerProps }: { containerProps?: Record<string, unknown>
     padding={10}
     flexDirection="column"
     width="300px"
-    backgroundColor="neutral.c30"
     justifyContent="center"
     alignItems="center"
     {...containerProps}
   >
-    <Text maxWidth="200px" variant="small" color="palette.neutral.c60" textAlign="center">
-      If you put content that is bigger than the available space, the dropdown will fill the entire
-      space without overflowing and its inner container will scroll.
+    <Text variant="small" color="neutral.c60" textAlign="center">
+      If the children node of the dropdown is bigger than the available space, the dropdown will
+      restrict its own height to avoid overflowing and its inner container will scroll.
     </Text>
-    <Box height="100px" width="100px" backgroundColor="lightgreen" />
-    <Box height="120px" width="100px" backgroundColor="lightcoral" />
-    <Box height="200px" width="100px" backgroundColor="lightblue" />
-    <Box height="120px" width="100px" backgroundColor="lightcoral" />
+    <Box height="100px" width="100%" backgroundColor="primary.c100" />
+    <Box height="100px" width="100%" backgroundColor="primary.c90" />
+    <Box height="100px" width="100%" backgroundColor="primary.c80" />
+    <Box height="100px" width="100%" backgroundColor="primary.c70" />
+    <Box height="100px" width="100%" backgroundColor="primary.c60" />
   </Box>
 );
 
@@ -93,17 +94,22 @@ export const DropdownGeneric = (args: DropdownGenericProps): React.ReactNode => 
        * Calling DropdownTemplate as a function here to trick storybook into displaying
        * the actual code in "show code" instead of an opaque "DropdownTemplate" component
        *  */}
-      <Text variant="h3">Small content:</Text>
+      <Text variant="h5">Small content:</Text>
       {containerPropsPossibilities.map((containerProps) =>
         DropdownStoryTemplate({ ...args, containerProps }),
       )}
       <Divider variant="light" />
-      <Text variant="h3">Big content:</Text>
+      <Text variant="h5">Big content:</Text>
       {containerPropsPossibilities.map((containerProps) =>
         DropdownStoryTemplate({ ...args, big: true, containerProps }),
       )}
       <Divider variant="light" />
-      <Text variant="h3">Big content with max height:</Text>
+      <Text variant="h5">Big content (max height on child)</Text>
+      <Alert
+        type="info"
+        title="In the following examples, the component passed as a child has its own internal maxHeight
+        setup"
+      ></Alert>
       {containerPropsPossibilities.map((containerProps) =>
         DropdownStoryTemplate({ ...args, big: true, bigWithMaxHeight: true, containerProps }),
       )}

--- a/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
@@ -6,7 +6,14 @@ import DropdownGenericComponent, { Props as DropdownGenericProps } from ".";
 import Divider from "../../asorted/Divider";
 
 const SmallChild = () => (
-  <Flex padding={10} backgroundColor="neutral.c30" justifyContent="center" alignItems="center">
+  <Flex
+    height={200}
+    width={180}
+    padding={10}
+    backgroundColor="neutral.c30"
+    justifyContent="center"
+    alignItems="center"
+  >
     <Text variant="small" color="palette.neutral.c60" textAlign="center">
       I'm a simple div with a grey background and no margin passed as children of the dropdown
       component

--- a/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/DropdownGeneric.stories.tsx
@@ -16,12 +16,12 @@ const SmallChild = () => (
   >
     <Text variant="small" color="palette.neutral.c60" textAlign="center">
       I'm a simple div with a grey background and no margin passed as children of the dropdown
-      component
+      component.
     </Text>
   </Flex>
 );
 
-const BigChild = () => (
+const BigChild = ({ containerProps }: { containerProps?: Record<string, unknown> }) => (
   <Box
     padding={10}
     flexDirection="column"
@@ -29,10 +29,11 @@ const BigChild = () => (
     backgroundColor="neutral.c30"
     justifyContent="center"
     alignItems="center"
+    {...containerProps}
   >
     <Text maxWidth="200px" variant="small" color="palette.neutral.c60" textAlign="center">
-      If you put content that is bigger than the available space, the dropdown will have a maxHeight
-      and its inner container will scroll
+      If you put content that is bigger than the available space, the dropdown will fill the entire
+      space without overflowing and its inner container will scroll.
     </Text>
     <Box height="100px" width="100px" backgroundColor="lightgreen" />
     <Box height="120px" width="100px" backgroundColor="lightcoral" />
@@ -60,14 +61,23 @@ const BottomPlaceholder = () => (
 const DropdownStoryTemplate = (
   props: Omit<DropdownGenericProps, "children"> & {
     big?: boolean;
+    bigWithMaxHeight?: boolean;
     containerProps: Record<string, unknown>;
   },
 ) => {
-  const { containerProps = {}, big = false, ...rest } = props;
+  const { containerProps = {}, big = false, bigWithMaxHeight = false, ...rest } = props;
   return (
     <Flex flexDirection="column" {...containerProps}>
       <DropdownGenericComponent {...rest}>
-        {big ? <BigChild /> : <SmallChild />}
+        {big ? (
+          bigWithMaxHeight ? (
+            <BigChild containerProps={{ maxHeight: "400px", overflow: "scroll" }} />
+          ) : (
+            <BigChild />
+          )
+        ) : (
+          <SmallChild />
+        )}
       </DropdownGenericComponent>
       <BottomPlaceholder />
     </Flex>
@@ -75,6 +85,8 @@ const DropdownStoryTemplate = (
 };
 
 export const DropdownGeneric = (args: DropdownGenericProps): React.ReactNode => {
+  const alignItemsPossibilities = ["flex-start", "center", "flex-end"];
+  const containerPropsPossibilities = alignItemsPossibilities.map((alignItems) => ({ alignItems }));
   return (
     <Flex flexDirection="column" rowGap={5}>
       {/**
@@ -82,14 +94,19 @@ export const DropdownGeneric = (args: DropdownGenericProps): React.ReactNode => 
        * the actual code in "show code" instead of an opaque "DropdownTemplate" component
        *  */}
       <Text variant="h3">Small content:</Text>
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-start" } })}
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "center" } })}
-      {DropdownStoryTemplate({ ...args, containerProps: { alignItems: "flex-end" } })}
+      {containerPropsPossibilities.map((containerProps) =>
+        DropdownStoryTemplate({ ...args, containerProps }),
+      )}
       <Divider variant="light" />
       <Text variant="h3">Big content:</Text>
-      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "flex-start" } })}
-      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "center" } })}
-      {DropdownStoryTemplate({ ...args, big: true, containerProps: { alignItems: "flex-end" } })}
+      {containerPropsPossibilities.map((containerProps) =>
+        DropdownStoryTemplate({ ...args, big: true, containerProps }),
+      )}
+      <Divider variant="light" />
+      <Text variant="h3">Big content with max height:</Text>
+      {containerPropsPossibilities.map((containerProps) =>
+        DropdownStoryTemplate({ ...args, big: true, bigWithMaxHeight: true, containerProps }),
+      )}
     </Flex>
   );
 };

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -6,10 +6,6 @@ import Flex from "../../layout/Flex";
 import Box from "../../layout/Flex";
 import Text from "../../asorted/Text";
 
-const Container = styled(Box).attrs({
-  marginRight: 3,
-})``;
-
 const ButtonContainer = styled(Box).attrs({
   flexDirection: "row",
   width: "auto",
@@ -164,7 +160,7 @@ const DropdownGeneric = ({
   const color = disabled ? "neutral.c50" : "neutral.c100";
 
   return (
-    <Container ref={divRef}>
+    <Box ref={divRef}>
       <ButtonContainer
         ref={reference}
         onClick={handleClickButton}
@@ -192,7 +188,7 @@ const DropdownGeneric = ({
           {children}
         </DropdownContainer>
       )}
-    </Container>
+    </Box>
   );
 };
 

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -27,6 +27,7 @@ const ButtonContainer = styled(Box).attrs({
 const DropdownContainer = styled(Flex).attrs(({ theme }) => {
   const isLight = theme.colors.type === "light";
   return {
+    zIndex: 1,
     flexDirection: "column",
     padding: 3,
     border: `1px solid ${theme.colors.neutral[isLight ? "c20" : "c30"]}`,

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -92,7 +92,6 @@ const DropdownGeneric = ({
   const divRef = useRef<HTMLDivElement>(null);
 
   const [maxHeight, setMaxHeight] = useState<number>();
-  // const [maxWidth, setMaxWidth] = useState<number>();
 
   const [opened, setOpened] = useState(false);
 

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -67,7 +67,7 @@ export type Props = {
    */
   children: React.ReactNode;
   /**
-   * Horizontal position of the dropdown relative to the dropdown button.
+   * Vertical alignment of the dropdown relative to the dropdown button.
    * Will automatically adjust to the document to avoid overflowing.
    * Defaults to "bottom".
    */

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -2,8 +2,13 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useFloating, getScrollParents, shift, size, flip } from "@floating-ui/react-dom";
 import styled from "styled-components";
 import { Icons } from "../../../";
+import Flex from "../../layout/Flex";
 import Box from "../../layout/Flex";
 import Text from "../../asorted/Text";
+
+const Container = styled(Box).attrs({
+  marginRight: 3,
+})``;
 
 const ButtonContainer = styled(Box).attrs({
   flexDirection: "row",
@@ -15,11 +20,11 @@ const ButtonContainer = styled(Box).attrs({
   > :last-child {
     /* targeting the dropdown icon */
     ${(p) => p.opened && "transform: rotate(180deg);"}
-    margin: 0px ${(p) => p.theme.space[3]}px;
+    margin-left: ${(p) => p.theme.space[3]}px;
   }
 `;
 
-const DropdownContainer = styled(Box).attrs(({ theme }) => {
+const DropdownContainer = styled(Flex).attrs(({ theme }) => {
   const isLight = theme.colors.type === "light";
   return {
     flexDirection: "column",
@@ -70,9 +75,9 @@ export type Props = {
   /**
    * Controls whether the dropdown will flip its side to keep it in view
    * in case there isn't enough space available. See https://floating-ui.com/docs/flip
-   * Defaults to true.
+   * Defaults to false.
    */
-  flipEnabled?: boolean;
+  flipDisabled?: boolean;
 };
 
 const DropdownGeneric = ({
@@ -81,7 +86,7 @@ const DropdownGeneric = ({
   closeOnClickInside = false,
   disabled = false,
   placement = "bottom",
-  flipEnabled = true,
+  flipDisabled = false,
   children,
 }: Props) => {
   const divRef = useRef<HTMLDivElement>(null);
@@ -103,7 +108,7 @@ const DropdownGeneric = ({
     placement: placements.includes(placement) ? placement : "bottom",
     middleware: [
       shift(),
-      ...(flipEnabled ? [flip()] : []),
+      ...(flipDisabled ? [] : [flip()]),
       size({
         padding: 6,
         apply({ height }) {
@@ -135,7 +140,7 @@ const DropdownGeneric = ({
         parent.removeEventListener("resize", handleResizeOrScroll);
       });
     };
-  }, [flipEnabled, opened, disabled, refs.reference, refs.floating, handleResizeOrScroll]);
+  }, [flipDisabled, refs.reference, refs.floating, handleResizeOrScroll]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -157,7 +162,7 @@ const DropdownGeneric = ({
   const color = disabled ? "neutral.c50" : "neutral.c100";
 
   return (
-    <div ref={divRef}>
+    <Container ref={divRef}>
       <ButtonContainer
         ref={reference}
         onClick={handleClickButton}
@@ -183,7 +188,7 @@ const DropdownGeneric = ({
           {children}
         </DropdownContainer>
       )}
-    </div>
+    </Container>
   );
 };
 

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useFloating, getScrollParents, shift, flip } from "@floating-ui/react-dom";
+import { useFloating, getScrollParents, shift, size, flip } from "@floating-ui/react-dom";
 import styled from "styled-components";
 import { Icons } from "../../../";
-import Flex from "../../layout/Flex";
 import Box from "../../layout/Flex";
 import Text from "../../asorted/Text";
 
@@ -20,10 +19,9 @@ const ButtonContainer = styled(Box).attrs({
   }
 `;
 
-const DropdownContainer = styled(Flex).attrs(({ theme }) => {
+const DropdownContainer = styled(Box).attrs(({ theme }) => {
   const isLight = theme.colors.type === "light";
   return {
-    display: "flex",
     flexDirection: "column",
     padding: 3,
     border: `1px solid ${theme.colors.neutral[isLight ? "c20" : "c30"]}`,
@@ -32,6 +30,7 @@ const DropdownContainer = styled(Flex).attrs(({ theme }) => {
     color: theme.colors.neutral.c80,
   };
 })`
+  overflow: scroll;
   box-shadow: 0px 6px 12px rgba(0, 0, 0, ${(p) => (p.theme.colors.type === "light" ? 0.04 : 0.08)});
 `;
 
@@ -68,6 +67,12 @@ export type Props = {
    * Defaults to "bottom".
    */
   placement?: Placement;
+  /**
+   * Controls whether the dropdown will flip its side to keep it in view
+   * in case there isn't enough space available. See https://floating-ui.com/docs/flip
+   * Defaults to true.
+   */
+  flipEnabled?: boolean;
 };
 
 const DropdownGeneric = ({
@@ -76,9 +81,13 @@ const DropdownGeneric = ({
   closeOnClickInside = false,
   disabled = false,
   placement = "bottom",
+  flipEnabled = true,
   children,
 }: Props) => {
   const divRef = useRef<HTMLDivElement>(null);
+
+  const [maxHeight, setMaxHeight] = useState<number>();
+  // const [maxWidth, setMaxWidth] = useState<number>();
 
   const [opened, setOpened] = useState(false);
 
@@ -92,7 +101,16 @@ const DropdownGeneric = ({
 
   const { x, y, reference, floating, strategy, update, refs } = useFloating({
     placement: placements.includes(placement) ? placement : "bottom",
-    middleware: [shift(), flip()],
+    middleware: [
+      shift(),
+      ...(flipEnabled ? [flip()] : []),
+      size({
+        padding: 6,
+        apply({ height }) {
+          setMaxHeight(height);
+        },
+      }),
+    ],
   });
 
   const handleResizeOrScroll = useCallback(() => {
@@ -117,7 +135,7 @@ const DropdownGeneric = ({
         parent.removeEventListener("resize", handleResizeOrScroll);
       });
     };
-  }, [opened, disabled, refs.reference, refs.floating, handleResizeOrScroll]);
+  }, [flipEnabled, opened, disabled, refs.reference, refs.floating, handleResizeOrScroll]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -154,7 +172,12 @@ const DropdownGeneric = ({
       {opened && !disabled && (
         <DropdownContainer
           ref={floating}
-          style={{ overflow: "visible", position: strategy, top: y ?? "", left: x ?? "" }}
+          style={{
+            position: strategy,
+            top: y ?? "",
+            left: x ?? "",
+            maxHeight: maxHeight ? `${maxHeight}px` : "",
+          }}
           onClick={handleClickInside}
         >
           {children}

--- a/packages/react/src/components/form/DropdownGeneric/index.tsx
+++ b/packages/react/src/components/form/DropdownGeneric/index.tsx
@@ -35,7 +35,7 @@ const DropdownContainer = styled(Flex).attrs(({ theme }) => {
     color: theme.colors.neutral.c80,
   };
 })`
-  overflow: scroll;
+  overflow-y: auto;
   box-shadow: 0px 6px 12px rgba(0, 0, 0, ${(p) => (p.theme.colors.type === "light" ? 0.04 : 0.08)});
 `;
 
@@ -92,6 +92,7 @@ const DropdownGeneric = ({
   const divRef = useRef<HTMLDivElement>(null);
 
   const [maxHeight, setMaxHeight] = useState<number>();
+  const [maxWidth, setMaxWidth] = useState<number>();
 
   const [opened, setOpened] = useState(false);
 
@@ -110,8 +111,9 @@ const DropdownGeneric = ({
       ...(flipDisabled ? [] : [flip()]),
       size({
         padding: 6,
-        apply({ height }) {
+        apply({ height, width }) {
           setMaxHeight(height);
+          setMaxWidth(width);
         },
       }),
     ],
@@ -181,6 +183,8 @@ const DropdownGeneric = ({
             top: y ?? "",
             left: x ?? "",
             maxHeight: maxHeight ? `${maxHeight}px` : "",
+            maxWidth: maxWidth ? "" : "",
+            // maxWidth: maxWidth ? `${maxWidth}px` : "", /* TODO: fix this */
           }}
           onClick={handleClickInside}
         >


### PR DESCRIPTION
- Avoid overflowing screen by having a dynamic maxHeight & overflow: scroll on the dropdown component.
- Add more storybook examples on how the component can handle potentially overflowing content.
- Add this prop for more control of the dropdown's behavior:
```ts
  /**
   * Controls whether the dropdown will flip its side to keep it in view
   * in case there isn't enough space available. See https://floating-ui.com/docs/flip
   * Defaults to false.
   */
  flipDisabled?: boolean;
```

https://user-images.githubusercontent.com/91890529/147656456-944c3737-9046-40cd-bab0-1dad3ef82f88.mov


