### PR TITLE
Native - Modals -> Use BoxedIcon; fix margins

### DIFF
--- a/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -24,7 +24,7 @@ export type BaseModalProps = {
   title?: string;
   description?: string;
   subtitle?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 } & Partial<ModalProps>;
 
 const Container = styled.View`
@@ -59,7 +59,6 @@ const StyledDescription = styled(Text).attrs({
   variant: "body",
   color: "neutral.c80",
 })`
-  text-transform: capitalize;
   margin-top: ${(p) => p.theme.space[2]}px;
 `;
 
@@ -122,12 +121,7 @@ export default function BaseModal({
               {React.isValidElement(Icon) ? (
                 Icon
               ) : (
-                <BoxedIcon
-                  size={64}
-                  Icon={Icon}
-                  iconSize={24}
-                  iconColor={iconColor}
-                />
+                <BoxedIcon size={64} Icon={Icon} iconSize={24} iconColor={iconColor} />
               )}
             </Flex>
           )}

--- a/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import ReactNativeModal, { ModalProps } from "react-native-modal";
-import styled, { useTheme } from "styled-components/native";
+import styled from "styled-components/native";
 import { StyleProp, ViewStyle } from "react-native";
 
 import sizes from "../../../../helpers/getDeviceSize";
 import Link from "../../../cta/Link";
 import CloseMedium from "@ledgerhq/icons-ui/native/CloseMedium";
-import FlexBox from "../../../Layout/Flex";
 import Text from "../../../Text";
+import { IconOrElementType } from "../../../Icon/type";
+import { BoxedIcon } from "../../../Icon";
+import { Flex } from "../../index";
 
 const { width, height } = sizes;
 
@@ -17,7 +19,7 @@ export type BaseModalProps = {
   modalStyle?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
   preventBackdropClick?: boolean;
-  Icon?: ((props: { size?: number; color?: string }) => React.ReactNode) | React.ReactNode;
+  Icon?: IconOrElementType;
   iconColor?: string;
   title?: string;
   description?: string;
@@ -66,6 +68,7 @@ const StyledSubtitle = styled(Text).attrs({
   color: "neutral.c80",
 })`
   text-transform: uppercase;
+  text-align: center;
   margin-bottom: ${(p) => p.theme.space[2]}px;
 `;
 
@@ -88,8 +91,6 @@ export default function BaseModal({
   children,
   ...rest
 }: BaseModalProps): React.ReactElement {
-  const { colors } = useTheme();
-
   const backDropProps = preventBackdropClick
     ? {}
     : {
@@ -117,14 +118,18 @@ export default function BaseModal({
         </CloseContainer>
         <HeaderContainer>
           {Icon && (
-            <FlexBox mb={24}>
-              {typeof Icon === "function"
-                ? Icon({
-                    size: 48,
-                    color: iconColor || colors.neutral.c100,
-                  })
-                : Icon}
-            </FlexBox>
+            <Flex mb={7}>
+              {React.isValidElement(Icon) ? (
+                Icon
+              ) : (
+                <BoxedIcon
+                  size={64}
+                  Icon={Icon}
+                  iconSize={24}
+                  iconColor={iconColor}
+                />
+              )}
+            </Flex>
           )}
           {subtitle && <StyledSubtitle>{subtitle}</StyledSubtitle>}
           {title && <StyledTitle>{title}</StyledTitle>}

--- a/packages/native/src/components/Layout/Modals/Popin/index.tsx
+++ b/packages/native/src/components/Layout/Modals/Popin/index.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components/native";
 
 import BaseModal, { BaseModalProps } from "../BaseModal";
 import Text from "../../../Text";
-import IconBox from "../../../Icon/IconBox";
 import Button, { ButtonProps } from "../../../cta/Button";
 
 const FooterButtonsContainer = styled.View`
@@ -23,26 +22,19 @@ const modalStyleOverrides = StyleSheet.create({
 
 export default function Popin({
   children,
-  Icon,
-  iconColor,
   leftButtonText = "Cancel",
   rightButtonText = "Delete",
   onLeftButtonPress,
   onRightButtonPress,
   ...restProps
 }: BaseModalProps & {
-  Icon: (props: { size?: number; color?: string }) => React.ReactElement;
   leftButtonText?: string;
   rightButtonText?: string;
   onLeftButtonPress?: ButtonProps["onPress"];
   onRightButtonPress?: ButtonProps["onPress"];
 }): React.ReactElement {
   return (
-    <BaseModal
-      {...restProps}
-      containerStyle={modalStyleOverrides.container}
-      Icon={Icon ? <IconBox Icon={Icon} color={iconColor} /> : null}
-    >
+    <BaseModal {...restProps} containerStyle={modalStyleOverrides.container}>
       {children}
       <FooterButtonsContainer>
         <Button


### PR DESCRIPTION
Display Icon inside a BoxedIcon, as described by the library figma. Nonetheless, it's still possible to use any react element as Icon  for exceptions in the figma.