### PR TITLE
Fix GraphTabs item borderRadius not working on iOS

### DIFF
--- a/packages/native/src/components/Tabs/Graph/index.tsx
+++ b/packages/native/src/components/Tabs/Graph/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components/native";
 import Text from "../../Text";
-import { TouchableOpacity } from "react-native";
 import TemplateTabs, { BaseTabsProps, TabItemProps } from "../TemplateTabs";
 
 type GraphTabSize = "small" | "medium";
@@ -14,10 +13,12 @@ type GraphTabItemProps = TabItemProps & {
   size?: GraphTabSize;
 };
 
-const TabBox = styled(TouchableOpacity)`
+const TabBox = styled.TouchableOpacity`
   text-align: center;
   margin: auto;
   flex: 1;
+  border-radius: 48px;
+  overflow: hidden;
 `;
 
 const TabText = styled(Text).attrs<GraphTabItemProps>((p) => ({
@@ -25,13 +26,12 @@ const TabText = styled(Text).attrs<GraphTabItemProps>((p) => ({
   size: undefined,
   lineHeight: p.size === "medium" ? "36px" : "26px",
   textAlign: "center",
-  borderRadius: 48,
   px: p.theme.space[p.size === "medium" ? 7 : 6],
   height: p.size === "medium" ? 36 : 26,
 }))``;
 
 const StyledTabs = styled(TemplateTabs)<GraphTabsProps>`
-  border: ${(p) => `1px solid ${p.theme.colors.palette.neutral.c40}`};
+  border: ${(p) => `1px solid ${p.theme.colors.neutral.c40}`};
   border-radius: 35px;
   padding: ${(p) => `${p.theme.space[p.size === "medium" ? 2 : 1]}px`};
 `;


### PR DESCRIPTION
Setting the `borderRadius` style prop on the TouchableOpacity rather than on the `Text` component (that does not work properly on iOS).

✅ Also tested & working on android & web storybook.

**Edit:** actually borderRadius works on the `Text` component only with `overflow: "hidden"` but it does not behave the same as for a `View` type component: if you set a `borderRadius` value higher that half of the length of one of the two attached "sides", it will look like that:
<img width="82" alt="Screenshot 2022-02-01 at 12 50 50" src="https://user-images.githubusercontent.com/91890529/151963548-36c65098-1ad1-4d4e-93e4-c3e933587f41.png">

### Illustration

![Combined](https://user-images.githubusercontent.com/91890529/151960728-bddd3bf9-ce81-4fe2-af0f-b9340ea44654.jpg)
