### PR TITLE
Native - ScrollContainerHeader - Export horizontal padding

### DIFF
--- a/packages/native/src/components/Layout/ScrollContainerHeader/Header.tsx
+++ b/packages/native/src/components/Layout/ScrollContainerHeader/Header.tsx
@@ -13,8 +13,10 @@ export type HeaderProps = {
   currentPositionY: Animated.SharedValue<number>;
 };
 
+const PADDING_HORIZONTAL = 16;
+
 const Container = styled(Flex).attrs({
-  paddingHorizontal: 16,
+  paddingHorizontal: PADDING_HORIZONTAL,
 })`
   background-color: ${(p) => p.theme.colors.background.main};
   width: 100%;
@@ -158,5 +160,7 @@ const Header = ({
     </Container>
   );
 };
+
+Header.PADDING_HORIZONTAL = PADDING_HORIZONTAL;
 
 export default Header;

--- a/packages/native/src/components/Layout/ScrollContainerHeader/index.tsx
+++ b/packages/native/src/components/Layout/ScrollContainerHeader/index.tsx
@@ -58,4 +58,6 @@ const ScrollContainerHeader = ({
   );
 };
 
+ScrollContainerHeader.Header = Header;
+
 export default ScrollContainerHeader;


### PR DESCRIPTION
Exposing `ScrollContainerHeader.Header` component and its horizontal padding `ScrollContainerHeader.Header.PADDING_HORIZONTAL`.

This allows overflowing accurately by using the value as a negative margin (useful for horizontal scroll stuff like filters etc.):

## Example of a use of this padding:
### Before:
https://user-images.githubusercontent.com/91890529/151974589-7a7f8815-24e0-4b49-bab9-407e28f0da0e.mp4

### After: (using the value of the padding as a negative horizontal margin)

```jsx
const overflowX = ScrollContainerHeader.Header.PADDING_HORIZONTAL;
  return (
    <ScrollContainer // Not to be confused with the ScrollContainerHeader, this is just another component from the lib, this could be any other component here
      style={{ marginHorizontal: -overflowX }}
      contentContainerStyle={{ paddingHorizontal: overflowX }}
      horizontal
    >
    {...}
</ScrollContainer>
```

https://user-images.githubusercontent.com/91890529/151974648-6182caec-e8dd-48a8-bcc5-f3b101ee7166.mp4


