### PR TITLE
Native - ProgressLoader progress fix & improvements

### DIFF
--- a/packages/native/src/components/Loader/ProgressLoader/index.tsx
+++ b/packages/native/src/components/Loader/ProgressLoader/index.tsx
@@ -27,6 +27,8 @@ type Props = {
   strokeWidth: number;
 
   children: React.ReactNode;
+
+  frontStrokeLinecap?: "butt" | "round";
 };
 
 const ProgressLoader = ({
@@ -37,6 +39,7 @@ const ProgressLoader = ({
   onPress,
   radius = 48,
   strokeWidth = 4,
+  frontStrokeLinecap,
   children,
 }: Props): React.ReactElement => {
   const { colors } = useTheme();
@@ -46,7 +49,7 @@ const ProgressLoader = ({
   const normalizedRadius = radius - strokeWidth / 2;
   const circumference = normalizedRadius * 2 * Math.PI;
 
-  const strokeDashoffset = circumference - progress * circumference;
+  const strokeDashoffset = circumference * (1 - progress);
 
   const rotation = useSharedValue(0);
   const animatedStyles = useAnimatedStyle(
@@ -95,7 +98,7 @@ const ProgressLoader = ({
                 strokeWidth={strokeWidth}
                 strokeDasharray={`${circumference / 4}, ${circumference}`}
                 strokeDashoffset="500"
-                strokeLinecap="round"
+                strokeLinecap={frontStrokeLinecap}
               />
             </Svg>
           </Animated.View>
@@ -112,7 +115,7 @@ const ProgressLoader = ({
           <Circle
             cx={radius}
             cy={radius}
-            r={radius * 0.92}
+            r={normalizedRadius}
             fill="transparent"
             stroke={backgroundColor}
             strokeDashoffset={0}
@@ -122,12 +125,13 @@ const ProgressLoader = ({
             <Circle
               cx={radius}
               cy={radius}
-              r={radius * 0.92}
+              r={normalizedRadius}
               fill="transparent"
               stroke={progressColor}
               strokeWidth={strokeWidth}
               strokeDasharray={`${circumference} ${circumference}`}
               strokeDashoffset={strokeDashoffset}
+              strokeLinecap={frontStrokeLinecap}
             />
           </G>
         </Svg>

--- a/packages/native/src/components/Loader/ProgressLoader/index.tsx
+++ b/packages/native/src/components/Loader/ProgressLoader/index.tsx
@@ -85,7 +85,7 @@ const ProgressLoader = ({
                 cx={radius}
                 cy={radius}
                 fill="transparent"
-                r={radius * 0.92}
+                r={normalizedRadius}
                 stroke={backgroundColor}
                 strokeWidth={strokeWidth}
               />
@@ -93,7 +93,7 @@ const ProgressLoader = ({
                 cx={radius}
                 cy={radius}
                 fill="transparent"
-                r={radius * 0.92}
+                r={normalizedRadius}
                 stroke={mainColor}
                 strokeWidth={strokeWidth}
                 strokeDasharray={`${circumference / 4}, ${circumference}`}

--- a/packages/native/src/components/Loader/ProgressLoader/index.tsx
+++ b/packages/native/src/components/Loader/ProgressLoader/index.tsx
@@ -39,7 +39,7 @@ const ProgressLoader = ({
   onPress,
   radius = 48,
   strokeWidth = 4,
-  frontStrokeLinecap,
+  frontStrokeLinecap = "butt",
   children,
 }: Props): React.ReactElement => {
   const { colors } = useTheme();

--- a/packages/native/storybook/stories/Loader/ProgressLoader.stories.tsx
+++ b/packages/native/storybook/stories/Loader/ProgressLoader.stories.tsx
@@ -1,21 +1,33 @@
 import React from "react";
 import { storiesOf } from "../storiesOf";
-import { number, color, boolean } from "@storybook/addon-knobs";
+import { number, color, boolean, select } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { Icons, ProgressLoader } from "../../../src";
+import { useTheme } from "styled-components/native";
+import { Text, ProgressLoader } from "../../../src";
 
-const LoaderSample = () => (
-  <ProgressLoader
-    progress={number("progress", 0.2)}
-    infinite={boolean("infinite", false)}
-    onPress={action("onPress")}
-    mainColor={color("mainColor", "primary.c80")}
-    secondaryColor={color("secondaryColor", "neutral.c40")}
-    radius={number("radius", 48)}
-    strokeWidth={number("strokeWidth", 4)}
-  >
-    <Icons.StarMedium />
-  </ProgressLoader>
-);
+const LoaderSample = () => {
+  const { colors } = useTheme();
+  const mainColor = colors.primary.c80;
+  const secondaryColor = colors.primary.c40;
+  const progress = number("progress", 0.5, { min: 0, max: 1, step: 0.1 });
+  return (
+    <ProgressLoader
+      progress={progress}
+      infinite={boolean("infinite", false)}
+      onPress={action("onPress")}
+      mainColor={color("mainColor", mainColor)}
+      secondaryColor={color("secondaryColor", secondaryColor)}
+      radius={number("radius", 48)}
+      strokeWidth={number("strokeWidth", 10)}
+      frontStrokeLinecap={select("frontStrokeLinecap", ["butt", "round"], "butt")}
+    >
+      {
+        <Text textAlign="center">
+          (children{"\n"} {progress * 100}%)
+        </Text>
+      }
+    </ProgressLoader>
+  );
+};
 
 storiesOf((story) => story("Loader", module).add("ProgressLoader", LoaderSample));


### PR DESCRIPTION
- Fix progress offset
- Fix default colors in story
- Add `frontStrokeLinecap` prop

### Before
- default colors from palette so not parsed (because under the hood it's using react-native-svg so it cannot interpolate colors from our palettes)
- wrong progress stroke offset (the progress is set to 0.5 and that is not reflected in the svg) due to a mismatch between the way the offset is calculated and the way the radius is calculated (it was using a hardcoded value)
- ☆ icon used to illustrate the `children` prop, in my opinion this is not very communicative to the end user of the storybook


> https://user-images.githubusercontent.com/91890529/157087078-408e2e6b-35b0-4f76-9db4-3fe9b534079a.mov



### After

- default colors working
- proper offset (see at 50%)
- more explicit `children` example
- options for stroke linecap (`"butt"` or `"round"`)


> https://user-images.githubusercontent.com/91890529/157086639-f1497da0-2a70-480a-9d63-02b53d6bd056.mov


