### PR TITLE
Native - ProgressLoader default props

### DIFF
--- a/packages/native/src/components/Loader/ProgressLoader/index.tsx
+++ b/packages/native/src/components/Loader/ProgressLoader/index.tsx
@@ -14,19 +14,21 @@ import Animated, {
 } from "react-native-reanimated";
 
 type Props = {
-  // float number between 0 and 1
+  /**
+   * float number between 0 and 1
+   */
   progress?: number;
-  infinite: boolean;
+  infinite?: boolean;
 
   onPress?: () => void;
 
-  mainColor: string;
-  secondaryColor: string;
+  mainColor?: string;
+  secondaryColor?: string;
 
-  radius: number;
-  strokeWidth: number;
+  radius?: number;
+  strokeWidth?: number;
 
-  children: React.ReactNode;
+  children?: React.ReactNode;
 
   frontStrokeLinecap?: "butt" | "round";
 };
@@ -43,7 +45,7 @@ const ProgressLoader = ({
   children,
 }: Props): React.ReactElement => {
   const { colors } = useTheme();
-  const backgroundColor = secondaryColor || colors.neutral.c40;
+  const backgroundColor = secondaryColor || colors.primary.c30;
   const progressColor = mainColor || colors.primary.c80;
 
   const normalizedRadius = radius - strokeWidth / 2;
@@ -94,7 +96,7 @@ const ProgressLoader = ({
                 cy={radius}
                 fill="transparent"
                 r={normalizedRadius}
-                stroke={mainColor}
+                stroke={progressColor}
                 strokeWidth={strokeWidth}
                 strokeDasharray={`${circumference / 4}, ${circumference}`}
                 strokeDashoffset="500"

--- a/packages/native/storybook/stories/Loader/ProgressLoader.stories.tsx
+++ b/packages/native/storybook/stories/Loader/ProgressLoader.stories.tsx
@@ -2,21 +2,17 @@ import React from "react";
 import { storiesOf } from "../storiesOf";
 import { number, color, boolean, select } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { useTheme } from "styled-components/native";
 import { Text, ProgressLoader } from "../../../src";
 
 const LoaderSample = () => {
-  const { colors } = useTheme();
-  const mainColor = colors.primary.c80;
-  const secondaryColor = colors.primary.c40;
   const progress = number("progress", 0.5, { min: 0, max: 1, step: 0.1 });
   return (
     <ProgressLoader
       progress={progress}
       infinite={boolean("infinite", false)}
       onPress={action("onPress")}
-      mainColor={color("mainColor", mainColor)}
-      secondaryColor={color("secondaryColor", secondaryColor)}
+      mainColor={color("mainColor", "")}
+      secondaryColor={color("secondaryColor", "")}
       radius={number("radius", 48)}
       strokeWidth={number("strokeWidth", 10)}
       frontStrokeLinecap={select("frontStrokeLinecap", ["butt", "round"], "butt")}


### PR DESCRIPTION
Making all props optional & properly defaulted.
I used the colors from the design system (replacing neutral.c40 by primary.c30 as the default background color)
Also removing default colors from the story as they're not being recomputed in the knobs when the theme changes so it leads to strange results (light colors in dark mode & vice versa).