### PR TITLE
Native - Alert - Add Icon & renderContent props to Alert component

### DIFF
--- a/packages/native/src/components/message/Alert/index.tsx
+++ b/packages/native/src/components/message/Alert/index.tsx
@@ -9,11 +9,15 @@ import FlexBox from "../../Layout/Flex";
 
 type AlertType = "info" | "warning" | "error";
 
+export type IconProps = { size?: number; color?: string };
+export type IconType = React.ComponentType<IconProps>;
 export interface AlertProps {
   type?: AlertType;
+  Icon?: IconType;
   title?: string;
   showIcon?: boolean;
   children?: React.ReactNode;
+  renderContent?: ({ textColor }: { textColor: string }) => React.ReactNode | null;
 }
 
 const icons = {
@@ -55,17 +59,20 @@ const StyledAlertContainer = styled(FlexBox).attrs<Partial<AlertProps>>((p) => (
 
 export default function Alert({
   type = "info",
+  Icon,
   title,
   showIcon = true,
   children,
+  renderContent,
 }: AlertProps): JSX.Element {
   const theme = useTheme();
   const textColor = getColor(theme, alertColors[type || "info"].color);
+  const iconProps = { size: 20, color: textColor };
   return (
     <StyledAlertContainer type={type}>
       {showIcon && !!icons[type] && (
         <StyledIconContainer>
-          {icons[type || "info"]({ size: 20, color: textColor })}
+          {Icon ? <Icon {...iconProps} /> : icons[type || "info"](iconProps)}
         </StyledIconContainer>
       )}
       {title && (
@@ -74,6 +81,7 @@ export default function Alert({
         </Text>
       )}
       {children}
+      {renderContent && renderContent({ textColor })}
     </StyledAlertContainer>
   );
 }

--- a/packages/native/src/components/message/Alert/index.tsx
+++ b/packages/native/src/components/message/Alert/index.tsx
@@ -13,10 +13,18 @@ export type IconProps = { size?: number; color?: string };
 export type IconType = React.ComponentType<IconProps>;
 export interface AlertProps {
   type?: AlertType;
+  /**
+   * Optional component to replace the default Icon for the given `type` prop.
+   * It will receive a `color: string` and a `size: number` as props.
+   * */
   Icon?: IconType;
   title?: string;
   showIcon?: boolean;
   children?: React.ReactNode;
+  /**
+   * Alternative to using the `children` prop in order to render something using the value of `textColor`
+   * that is passed as a parameter.
+   */
   renderContent?: ({ textColor }: { textColor: string }) => React.ReactNode | null;
 }
 

--- a/packages/native/src/components/message/Alert/index.tsx
+++ b/packages/native/src/components/message/Alert/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled, { useTheme } from "styled-components/native";
-import ShieldSecurityMedium from "@ledgerhq/icons-ui/native/ShieldSecurityMedium";
+import InfoMedium from "@ledgerhq/icons-ui/native/InfoMedium";
 import CircledCrossMedium from "@ledgerhq/icons-ui/native/CircledCrossMedium";
 import CircledAlertMedium from "@ledgerhq/icons-ui/native/CircledAlertMedium";
 import Text from "../../Text";
@@ -29,7 +29,7 @@ export interface AlertProps {
 }
 
 const icons = {
-  info: ShieldSecurityMedium,
+  info: InfoMedium,
   warning: CircledAlertMedium,
   error: CircledCrossMedium,
 };

--- a/packages/native/storybook/stories/message/Alert/Alert.stories.tsx
+++ b/packages/native/storybook/stories/message/Alert/Alert.stories.tsx
@@ -2,17 +2,16 @@ import React from "react";
 import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../../storiesOf";
 import { select, boolean } from "@storybook/addon-knobs";
-import Alert from "../../../../src/components/message/Alert";
-import FlexBox from "../../../../src/components/Layout/Flex";
+import { Alert, Flex } from "../../../../src/";
 
 const AlertSample = () => (
-  <FlexBox p={20} width={1}>
+  <Flex p={20} width={1}>
     <Alert
       type={select("type", ["info", "warning", "error", undefined], undefined)}
       title={text("title", "Label")}
       showIcon={boolean("showIcon", true)}
     />
-  </FlexBox>
+  </Flex>
 );
 
 storiesOf((story) => story("Messages", module).add("Alert", AlertSample));


### PR DESCRIPTION
- Add `Icon` component prop to Alert -> this will be useful for more customisation possibility, the component passed to the `Icon` prop will be rendered with the right color & size as props.
- Add `renderContent` render prop that is called with `{textColor: string}` -> I didn't want to wrap `{children}` in a text component and potentially break existing uses, also the `textColor` can be used for icons (for instance a link icon) so it's useful to get it as a param of the render prop.
- Change icon for "info" type, following [the design system](https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/?node-id=2818%3A21227):
  <img width="696" alt="Screenshot 2022-03-08 at 19 55 56" src="https://user-images.githubusercontent.com/91890529/157306121-3d7d2629-0837-4dfb-adc6-d4884b435fd8.png">
 