### PR TITLE
Native - Log - Pixel perfect alignment of brackets & text on Android & iOS

### DIFF
--- a/packages/native/src/components/message/Log/Brackets.tsx
+++ b/packages/native/src/components/message/Log/Brackets.tsx
@@ -33,17 +33,17 @@ export const Bracket = ({ color, style, mb, mt }: BaseBracketProps): React.React
 };
 
 export const BracketTopLeft = ({ color }: BracketProps) => {
-  return <Bracket color={color} mb="-4px" />;
+  return <Bracket color={color} />;
 };
 
 export const BracketTopRight = ({ color }: BracketProps) => {
-  return <Bracket color={color} mb="-4px" style={{ transform: [{ scaleX: -1 }] }} />;
+  return <Bracket color={color} style={{ transform: [{ scaleX: -1 }] }} />;
 };
 
 export const BracketBottomLeft = ({ color }: BracketProps) => {
-  return <Bracket color={color} mt="-4px" style={{ transform: [{ scaleY: -1 }] }} />;
+  return <Bracket color={color} style={{ transform: [{ scaleY: -1 }] }} />;
 };
 
 export const BracketBottomRight = ({ color }: BracketProps) => {
-  return <Bracket color={color} mt="-4px" style={{ transform: [{ scale: -1 }] }} />;
+  return <Bracket color={color} style={{ transform: [{ scale: -1 }] }} />;
 };

--- a/packages/native/src/components/message/Log/index.tsx
+++ b/packages/native/src/components/message/Log/index.tsx
@@ -2,6 +2,7 @@ import React, { memo } from "react";
 import Text, { BaseTextProps as TextProps } from "../../Text";
 import Flex, { FlexBoxProps } from "../../Layout/Flex";
 import { BracketTopLeft, BracketTopRight, BracketBottomLeft, BracketBottomRight } from "./Brackets";
+import { Platform } from "react-native";
 
 export type Props = React.PropsWithChildren<
   FlexBoxProps & {
@@ -12,21 +13,31 @@ export type Props = React.PropsWithChildren<
 function Log({ children, extraTextProps }: Props): JSX.Element {
   return (
     <Flex flexDirection="column">
-      <Flex flexDirection="row" justifyContent="space-between">
+      <Flex
+        flexDirection="row"
+        justifyContent="space-between"
+        mb={Platform.OS === "android" ? "-2px" : "-6px"}
+      >
         <BracketTopLeft color="neutral.c100" />
         <BracketTopRight color="neutral.c100" />
       </Flex>
       <Text
         variant="h2"
+        lineHeight="28px"
         textTransform="uppercase"
         textAlign="center"
         color="neutral.c100"
-        px="16px"
+        px="15.5px"
+        style={{ overflow: "visible" }}
         {...extraTextProps}
       >
         {children}
       </Text>
-      <Flex flexDirection="row" justifyContent="space-between">
+      <Flex
+        mt={Platform.OS === "android" ? "-9.5px" : "-5px"}
+        flexDirection="row"
+        justifyContent="space-between"
+      >
         <BracketBottomLeft color="neutral.c100" />
         <BracketBottomRight color="neutral.c100" />
       </Flex>


### PR DESCRIPTION
There was an issue with alignment of brackets & text on Android, I decided to try to make it pixel perfect on both iOS and Android:

⚠️ the alignment is not perfect in the **web** storybook as I guess the implementations of lineHeight are slightly different depending on the platform and the new logic is just adapted to iOS & Android

Here's how the alignment looks now on Android & iOS:
![Combined](https://user-images.githubusercontent.com/91890529/158224800-fd939f2a-c612-43a6-a953-d10bf06aaa04.jpg)

