### PR TITLE
(Chart): fix issues with intl formatter + use transitin fade

### DIFF
--- a/packages/native/src/components/ChartCard/index.tsx
+++ b/packages/native/src/components/ChartCard/index.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { useTheme } from "styled-components/native";
-import { Flex, GraphTabs, InfiniteLoader } from "../index";
-import * as Animatable from "react-native-animatable";
+import { Flex, GraphTabs, InfiniteLoader, Transitions } from "../index";
 import Chart from "../chart";
 
 const ChartCard = ({
@@ -13,7 +12,7 @@ const ChartCard = ({
   chartData,
   currencyColor,
   margin = 0,
-  locale,
+  xAxisFormatter,
   ranges,
   yAxisFormatter,
   valueFormatter,
@@ -26,7 +25,7 @@ const ChartCard = ({
   chartData: any;
   currencyColor: string;
   margin: number;
-  locale: string;
+  xAxisFormatter?: (value: number) => string;
   ranges: { label: string; value: string }[];
   yAxisFormatter: (value: number) => string;
   valueFormatter: (value: number) => string;
@@ -46,37 +45,23 @@ const ChartCard = ({
     [isLoading, range, ranges, refreshChart],
   );
 
-  const timeFormat = useMemo(() => {
-    switch (ranges[activeRangeIndex].value) {
-      case "24h":
-        return { hour: "numeric", minute: "numeric" };
-      case "7d":
-        return { weekday: "short" };
-      case "30d":
-        return { month: "short", day: "numeric" };
-      default:
-        return { month: "short" };
-    }
-  }, [ranges, activeRangeIndex]);
-
   return (
     <Flex margin={margin} padding={6} borderRadius={2} bg={"neutral.c30"}>
       {Header}
       <Flex mt={6} height={100} alignItems="center" justifyContent="center">
         {chartData && chartData.length > 0 ? (
-          <Animatable.View animation="fadeIn" duration={400} useNativeDriver>
+          <Transitions.Fade status="entering" duration={400}>
             <Chart
-              locale={locale}
               data={chartData}
               backgroundColor={colors.neutral.c30}
               color={currencyColor}
-              timeFormat={timeFormat}
               valueKey={"value"}
+              xAxisFormatter={xAxisFormatter}
               yAxisFormatter={yAxisFormatter}
               valueFormatter={valueFormatter}
               disableTooltips={false}
             />
-          </Animatable.View>
+          </Transitions.Fade>
         ) : (
           <InfiniteLoader size={32} />
         )}

--- a/packages/native/src/components/chart/index.tsx
+++ b/packages/native/src/components/chart/index.tsx
@@ -25,30 +25,25 @@ export type ChartProps = {
   data: Array<Item>;
   backgroundColor: string;
   color: string;
-  /*
-   ** This prop is used to format the x-axis using time options from Intl.DateTimeFormat format
-   */
-  timeFormat?: any;
   /* This prop is used to override the key that store the data */
   valueKey?: string;
   height?: number;
+  xAxisFormatter?: (timestamp: number) => string;
   yAxisFormatter: (n: number) => string;
   valueFormatter: (n: number) => string;
   disableTooltips: boolean;
-  locale: string;
 };
 
 const Chart = ({
   data,
   backgroundColor,
   color,
-  timeFormat = { month: "short" },
-  valueKey = "value",
-  height = 200,
   yAxisFormatter,
   valueFormatter,
+  valueKey = "value",
+  height = 200,
+  xAxisFormatter = (timestamp: number): string => `${new Date(timestamp).toLocaleDateString()}`,
   disableTooltips = false,
-  locale,
 }: ChartProps): JSX.Element => {
   const theme = useTheme();
   const sortData = useMemo(() => data.sort(sortByDate), [data]);
@@ -138,11 +133,7 @@ const Chart = ({
         <VictoryAxis dependentAxis crossAxis tickFormat={yAxisFormatter} style={yAxisStyle} />
 
         {/* x-axis */}
-        <VictoryAxis
-          crossAxis={false}
-          tickFormat={(timestamp) => new Intl.DateTimeFormat(locale, timeFormat).format(timestamp)}
-          style={xAxisStyle}
-        />
+        <VictoryAxis crossAxis={false} tickFormat={xAxisFormatter} style={xAxisStyle} />
 
         {/* gradient area */}
         <Defs>

--- a/packages/native/storybook/stories/Chart/Chart.stories.tsx
+++ b/packages/native/storybook/stories/Chart/Chart.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "../storiesOf";
-import { color, text, object, boolean } from "@storybook/addon-knobs";
+import { color, text, boolean } from "@storybook/addon-knobs";
 import { useTheme } from "styled-components/native";
 
 import Chart from "../../../src/components/chart";
@@ -32,11 +32,9 @@ const ChartDefault = (): JSX.Element => {
   return (
     <Flex alignItems="flex-start" flexDirection="column">
       <Chart
-        locale={text("locale", "en")}
         data={generateData()}
         backgroundColor={color("backgroundColor", theme.colors.neutral.c30)}
         color={color("color", theme.colors.primary.c100)}
-        timeFormat={object("timeFormat", { month: "short" })}
         valueKey={text("valueKey", "value")}
         yAxisFormatter={(value) => value.toString()}
         valueFormatter={(value) => value.toString()}

--- a/packages/native/storybook/stories/ChartCard/ChartCard.stories.tsx
+++ b/packages/native/storybook/stories/ChartCard/ChartCard.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { storiesOf } from "../storiesOf";
-import { color, text, number, boolean } from "@storybook/addon-knobs";
+import { color, number, boolean } from "@storybook/addon-knobs";
 import { useTheme } from "styled-components/native";
 
 import ChartCard from "../../../src/components/ChartCard";
@@ -59,7 +59,6 @@ const ChartCardDefault = (): JSX.Element => {
         isLoading={boolean("isLoading", false)}
         currencyColor={color("currencyColor", theme.colors.primary.c100)}
         margin={number("margin", 0)}
-        locale={text("locale", "en")}
         yAxisFormatter={(v) => v.toString()}
         valueFormatter={(v) => v.toString()}
       />

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -42,6 +42,7 @@ import "./Layout/Table.stories";
 import "./Layout/Collapse/Accordion.stories";
 import "./Form/Slider/Slider.stories";
 import "./Chart/Chart.stories";
+import "./ChartCard/ChartCard.stories";
 import "./Form/SelectableList.stories";
 import "./Carousel/Carousel.stories";
 import "./ProgressBar/ProgressBar.stories";


### PR DESCRIPTION
![Screenshot_2022-03-15-15-30-27-174_host exp exponent](https://user-images.githubusercontent.com/11752937/158400929-acbeb043-1f89-4c95-bbf4-3a899677f93b.jpg)
![Screenshot_2022-03-15-15-30-35-392_host exp exponent](https://user-images.githubusercontent.com/11752937/158400949-19488484-e843-4634-aa81-4a92f6be1852.jpg)


Removal of non necessary props + fade in usage instead of animatable
