### PR TITLE
bugfix/selected-graph-tab-visibility-improved

### DIFF
--- a/packages/native/src/components/ChartCard/index.tsx
+++ b/packages/native/src/components/ChartCard/index.tsx
@@ -69,7 +69,8 @@ const ChartCard = ({
       <Flex mt={70}>
         <GraphTabs
           activeIndex={activeRangeIndex}
-          activeBg="neutral.c30"
+          activeBg={currencyColor}
+          activeColor="neutral.c30"
           onChange={setRange}
           labels={rangesLabels}
         />

--- a/packages/native/src/components/Tabs/Graph/index.tsx
+++ b/packages/native/src/components/Tabs/Graph/index.tsx
@@ -49,21 +49,16 @@ export const GraphTab = ({
     <TabBox onPress={onPress} disabled={disabled}>
       {isActive ? (
         <TabText
-          variant="body"
+          variant="small"
           size={size}
           bg={activeBg}
           color={disabled ? "neutral.c70" : activeColor}
-          fontWeight="bold"
+          fontWeight="semiBold"
         >
           {label}
         </TabText>
       ) : (
-        <TabText
-          variant="small"
-          size={size}
-          color={disabled ? "neutral.c70" : "neutral.c90"}
-          fontWeight="semiBold"
-        >
+        <TabText variant="small" size={size} color={disabled ? "neutral.c70" : "neutral.c90"}>
           {label}
         </TabText>
       )}

--- a/packages/native/src/components/Tabs/Graph/index.tsx
+++ b/packages/native/src/components/Tabs/Graph/index.tsx
@@ -49,16 +49,21 @@ export const GraphTab = ({
     <TabBox onPress={onPress} disabled={disabled}>
       {isActive ? (
         <TabText
-          variant="small"
+          variant="body"
           size={size}
           bg={activeBg}
           color={disabled ? "neutral.c70" : activeColor}
-          fontWeight="semiBold"
+          fontWeight="bold"
         >
           {label}
         </TabText>
       ) : (
-        <TabText variant="small" size={size} color={disabled ? "neutral.c70" : "neutral.c90"}>
+        <TabText
+          variant="small"
+          size={size}
+          color={disabled ? "neutral.c70" : "neutral.c90"}
+          fontWeight="semiBold"
+        >
           {label}
         </TabText>
       )}


### PR DESCRIPTION
ChartCard style slightly modified so the selected tab is more visible
https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3589046311/Pre-QA+feedbacks#:~:text=Can%20we%20make%20selected%20time%20range%20more%20highlight%20in%20dark%20mode%3F

Before
<img src="https://user-images.githubusercontent.com/17146928/159716594-8ce2d916-b718-4352-a20c-684d43de4c91.png" width="600" height="300" />
After
<img src="https://user-images.githubusercontent.com/17146928/159748900-322036d1-ce7c-4f87-a8a9-26da49d4d6c7.png" width="600" height="300" />

