### PR TITLE
add props uppercase to tag

### DIFF
--- a/packages/native/src/components/tags/Tag/index.tsx
+++ b/packages/native/src/components/tags/Tag/index.tsx
@@ -5,10 +5,11 @@ import Text from "../../Text";
 
 export interface TagProps extends FlexBoxProps {
   active?: boolean;
+  uppercase?: boolean;
   children: React.ReactNode;
 }
 
-export default function Tag({ active, children, ...props }: TagProps): JSX.Element {
+export default function Tag({ active, uppercase, children, ...props }: TagProps): JSX.Element {
   return (
     <Flex
       px={2}
@@ -23,7 +24,7 @@ export default function Tag({ active, children, ...props }: TagProps): JSX.Eleme
         variant="tiny"
         fontWeight="semiBold"
         lineHeight="16px"
-        textTransform="uppercase"
+        uppercase={uppercase !== false}
         textAlign="center"
         color={active ? "primary.c70" : "neutral.c80"}
       >

--- a/packages/native/storybook/stories/Tag/Tag.stories.tsx
+++ b/packages/native/storybook/stories/Tag/Tag.stories.tsx
@@ -4,6 +4,10 @@ import { boolean, text } from "@storybook/addon-knobs";
 import Tag from "../../../src/components/tags/Tag";
 import { storiesOf } from "../storiesOf";
 
-const TagSample = () => <Tag active={boolean("active", false)}>{text("children", "Label")}</Tag>;
+const TagSample = () => (
+  <Tag active={boolean("active", false)} uppercase={boolean("uppercase", true)}>
+    {text("children", "Label")}
+  </Tag>
+);
 
 storiesOf((story) => story("Tag", module).add("Tag", TagSample));


### PR DESCRIPTION
## Add a props uppercase 

We have to add this props to tags as we need to handle device names in non uppercase mod in LLM V3.
uppercase will still be defaulted to true unless we give false to this props.
Tested with undefined / without uppercase props.
 
![image](https://user-images.githubusercontent.com/90627435/159929003-4b77e288-fd84-4767-91bc-b14ae569f91c.png)
![image](https://user-images.githubusercontent.com/90627435/159929051-228f96b7-b59a-4d98-8a99-78cf384a2549.png)
