### PR TITLE
Native - Bigger hitboxes for close buttons in Modals & Notification

### DIFF
--- a/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -10,6 +10,7 @@ import Text from "../../../Text";
 import { IconOrElementType } from "../../../Icon/type";
 import { BoxedIcon } from "../../../Icon";
 import { Flex } from "../../index";
+import { space } from "styled-system";
 
 const { width, height } = sizes;
 
@@ -44,6 +45,13 @@ const CloseContainer = styled.View`
   display: flex;
   align-items: flex-end;
   margin-bottom: ${(p) => p.theme.space[7]}px;
+`;
+
+const ClosePressableExtendedBounds = styled.TouchableOpacity.attrs({
+  p: 5,
+  m: -5,
+})`
+  ${space};
 `;
 
 const StyledTitle = styled(Text).attrs({ variant: "h2" })`
@@ -136,7 +144,9 @@ export default function BaseModal({
       <Container style={containerStyle}>
         {!noCloseButton && (
           <CloseContainer>
-            <Link Icon={CloseMedium} onPress={onClose} />
+            <ClosePressableExtendedBounds onPress={onClose}>
+              <Link Icon={CloseMedium} onPress={onClose} />
+            </ClosePressableExtendedBounds>
           </CloseContainer>
         )}
         <ModalHeader

--- a/packages/native/src/components/message/Notification/index.tsx
+++ b/packages/native/src/components/message/Notification/index.tsx
@@ -5,6 +5,7 @@ import { TextProps, TouchableOpacity, TouchableOpacityProps } from "react-native
 import Text from "../../Text";
 import CloseMedium from "@ledgerhq/icons-ui/native/CloseMedium";
 import { Flex } from "../../Layout";
+import { space } from "styled-system";
 
 type Props = {
   Icon?: React.ComponentType<{ size: number; color?: string }>;
@@ -31,6 +32,13 @@ const NotificationContainer = styled.View<Partial<Props>>`
   background-color: ${(p) =>
     p.variant === "primary" ? p.theme.colors.primary.c90 : "transparent"};
   border-radius: ${(p) => `${p.theme.radii[1]}px`};
+`;
+
+const ClosePressableExtendedBounds = styled.TouchableOpacity.attrs({
+  p: 5,
+  m: -5,
+})`
+  ${space};
 `;
 
 export default function Notification({
@@ -85,9 +93,9 @@ export default function Notification({
       </FlexBox>
       {onClose && (
         <FlexBox marginLeft={"auto"} pl={16}>
-          <TouchableOpacity onPress={onClose}>
+          <ClosePressableExtendedBounds onPress={onClose}>
             <CloseMedium size={14} color={textColor} />
-          </TouchableOpacity>
+          </ClosePressableExtendedBounds>
         </FlexBox>
       )}
     </NotificationContainer>


### PR DESCRIPTION
#### BaseModal
> ![touch-modal](https://user-images.githubusercontent.com/91890529/160792292-9b10b00d-284e-4196-b59c-b95f4ea6e54b.jpg)

#### BottomDrawer
> ![touch-bottom](https://user-images.githubusercontent.com/91890529/160792314-107374c0-64a3-43ec-a358-75dd7bd3a246.jpg)

#### Notification
> ![touch-notification](https://user-images.githubusercontent.com/91890529/160793223-ee7df2cc-c265-46a8-b47e-2ff31c435f23.jpg)

