### PR TITLE
Native - Changes made to Text h4 variant and h5 variant added

### DIFF
--- a/packages/native/src/components/Text/getTextStyle.ts
+++ b/packages/native/src/components/Text/getTextStyle.ts
@@ -8,6 +8,7 @@ const bracketSizes: Record<TextVariants, number> = {
   h2: 28,
   h3: 20,
   h4: 18,
+  h5: 18,
   large: 20,
   body: 20,
   bodyLineHeight: 20,
@@ -52,7 +53,9 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
     },
     h4: {
       fontFamily: "Inter",
-      textTransform: "uppercase",
+    },
+    h5: {
+      fontFamily: "Inter",
     },
     large: {
       fontFamily: "Inter",

--- a/packages/native/src/styles/theme.ts
+++ b/packages/native/src/styles/theme.ts
@@ -8,6 +8,7 @@ export type TextVariants =
   | "h2"
   | "h3"
   | "h4"
+  | "h5"
   | "large"
   | "body"
   | "bodyLineHeight"
@@ -35,7 +36,8 @@ export const fontSizes = [10, 11, 12, 13, 14, 16, 18, 24, 28] as ThemeScale<numb
 ] = fontSizes;
 fontSizes.bodyLineHeight = fontSizes.body;
 fontSizes.paragraphLineHeight = fontSizes.paragraph;
-fontSizes.h4 = fontSizes.h3;
+fontSizes.h4 = fontSizes.h2;
+fontSizes.h5 = fontSizes.h3;
 
 export const radii = [0, 4, 8];
 export const zIndexes = [-1, 0, 1, 9, 10, 90, 100, 900, 1000];

--- a/packages/native/storybook/stories/Text/Text.stories.tsx
+++ b/packages/native/storybook/stories/Text/Text.stories.tsx
@@ -14,6 +14,7 @@ storiesOf((story) =>
           "h2",
           "h3",
           "h4",
+          "h5",
           "large",
           "body",
           "bodyLineHeight",

--- a/packages/native/storybook/stories/Text/TextOverview.stories.tsx
+++ b/packages/native/storybook/stories/Text/TextOverview.stories.tsx
@@ -6,7 +6,7 @@ import Text from "../../../src/components/Text";
 import { TextVariants } from "../../../src/styles/theme";
 import { storiesOf } from "../storiesOf";
 
-const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4"];
+const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4", "h5"];
 
 const mainVariants: TextVariants[] = [
   "large",


### PR DESCRIPTION
h4 changes (to match the fonts in the figma) :
- Removed the uppercase transformation
- h4 size fis now the same as h2 instead of h3

h5 variant added to ui lib as descibed in the figma (Inter and same size as h3) :
![Screenshot 2022-04-27 at 14 38 11](https://user-images.githubusercontent.com/17146928/165519664-195766de-c551-499b-92ed-d14ec3b7679d.png)

