### PR TITLE
Carousel : Add new options, and fixes / Add Story Indicator

### DIFF
--- a/packages/native/src/components/Carousel/index.tsx
+++ b/packages/native/src/components/Carousel/index.tsx
@@ -18,6 +18,10 @@ export type Props = React.PropsWithChildren<{
    */
   onChange?: (index: number) => void;
   /**
+   * Called when Carousel try to scroll before the first or after the last item (if restartAfterEnd is false).
+   */
+  onOverflow?: (side: "start" | "end", fromAutoDelay: boolean) => void;
+  /**
    * This number in milliseconds will enable automatic scrolling when defined.
    *
    * The Carousel will scroll to the next item after this delay is elapsed,
@@ -27,6 +31,14 @@ export type Props = React.PropsWithChildren<{
    * manually change the carousel item displayed.
    */
   autoDelay?: number;
+  /**
+   * When the delay is elasped, if the Carousel is at the last item, it will scroll back to the beginning.
+   */
+  restartAfterEnd?: boolean;
+  /**
+   * When the user tap on one side of an item, it will scroll to the next or precedent item. Same behavior as Instagram or Snapchat. Default: false.
+   */
+  scrollOnSidePress?: boolean;
   /**
    * Additional props to pass to the outer container.
    * This container is a Flex element.
@@ -42,15 +54,28 @@ export type Props = React.PropsWithChildren<{
    * This container is a Flex element.
    */
   slideIndicatorContainerProps?: FlexboxProps & ViewProps;
+
+  IndicatorComponent?:
+    | React.ComponentType<{
+        activeIndex: number;
+        slidesLength: number;
+        onChange?: (index: number) => void;
+        duration?: number;
+      }>
+    | React.ReactElement;
 }>;
 
 function Carousel({
-  activeIndex,
+  activeIndex = 0,
   autoDelay,
+  restartAfterEnd = true,
+  scrollOnSidePress = false,
   containerProps,
   slideIndicatorContainerProps,
   scrollViewProps,
   onChange,
+  onOverflow,
+  IndicatorComponent = SlideIndicator,
   children,
 }: Props) {
   const [init, setInit] = useState(false);
@@ -81,7 +106,9 @@ function Carousel({
 
   useEffect(() => {
     // On init scroll to the active index prop location - if specified.
-    if (init && activeIndex) scrollToIndex(activeIndex, false);
+    if (init && activeIndex) {
+      scrollToIndex(activeIndex, false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [init]);
 
@@ -97,6 +124,24 @@ function Carousel({
     setInit(true);
   };
 
+  const onTap = useCallback(
+    (event) => {
+      const tapPositionXPercent = event.nativeEvent.locationX / itemWidth;
+      if (tapPositionXPercent > 0.25) {
+        if (slidesLength > activeIndexState + 1) {
+          scrollToIndex(activeIndexState + 1, false);
+        } else {
+          onOverflow && onOverflow("end", false);
+        }
+      } else if (activeIndexState > 0) {
+        scrollToIndex(activeIndexState - 1, false);
+      } else {
+        onOverflow && onOverflow("start", false);
+      }
+    },
+    [slidesLength, activeIndexState, scrollToIndex, onOverflow, itemWidth],
+  );
+
   const onScroll = ({
     nativeEvent: { contentOffset, contentSize },
   }: {
@@ -110,19 +155,31 @@ function Carousel({
   useEffect(() => {
     if (!autoDelay) return;
 
-    const interval = setInterval(() => {
+    const interval = setTimeout(() => {
       if (!disableTimer.current) {
-        setActiveIndexState((index) => {
-          const newIndex = typeof index !== "undefined" ? (index + 1) % slidesLength : 0;
+        const newIndex =
+          typeof activeIndexState !== "undefined" ? (activeIndexState + 1) % slidesLength : 0;
+        if (restartAfterEnd || newIndex !== 0) {
           scrollToIndex(newIndex);
-          onChange && onChange(newIndex);
-          return newIndex;
-        });
+        } else {
+          onOverflow && onOverflow("end", true);
+        }
       }
     }, autoDelay);
 
-    return () => clearInterval(interval);
-  }, [resetTimer, slidesLength, scrollToIndex, onChange, autoDelay]);
+    return () => {
+      return clearTimeout(interval);
+    };
+  }, [
+    resetTimer,
+    slidesLength,
+    scrollToIndex,
+    onChange,
+    autoDelay,
+    activeIndexState,
+    onOverflow,
+    restartAfterEnd,
+  ]);
 
   return (
     <Flex flex={1} width="100%" alignItems="center" justifyContent="center" {...containerProps}>
@@ -141,6 +198,8 @@ function Carousel({
         scrollEventThrottle={200}
         contentContainerStyle={{ width: `${fullWidth}%` }}
         decelerationRate="fast"
+        disableIntervalMomentum={true}
+        onTouchEnd={scrollOnSidePress ? onTap : undefined}
         {...scrollViewProps}
       >
         {React.Children.map(children, (child, index) => (
@@ -150,14 +209,19 @@ function Carousel({
         ))}
       </HorizontalScrollView>
       <Flex my={8} {...slideIndicatorContainerProps}>
-        <SlideIndicator
-          activeIndex={activeIndexState || 0}
-          onChange={(index) => {
-            scrollToIndex(index);
-            setResetTimer({});
-          }}
-          slidesLength={slidesLength}
-        />
+        {React.isValidElement(IndicatorComponent) ? (
+          IndicatorComponent
+        ) : (
+          <IndicatorComponent
+            activeIndex={activeIndexState || 0}
+            onChange={(index: number) => {
+              scrollToIndex(index);
+              setResetTimer({});
+            }}
+            slidesLength={slidesLength}
+            duration={autoDelay}
+          />
+        )}
       </Flex>
     </Flex>
   );

--- a/packages/native/src/components/Carousel/index.tsx
+++ b/packages/native/src/components/Carousel/index.tsx
@@ -198,7 +198,6 @@ function Carousel({
         scrollEventThrottle={200}
         contentContainerStyle={{ width: `${fullWidth}%` }}
         decelerationRate="fast"
-        disableIntervalMomentum={true}
         onTouchEnd={scrollOnSidePress ? onTap : undefined}
         {...scrollViewProps}
       >

--- a/packages/native/src/components/Navigation/SlideIndicator/index.tsx
+++ b/packages/native/src/components/Navigation/SlideIndicator/index.tsx
@@ -10,7 +10,7 @@ import Animated, {
 type Props = {
   slidesLength: number;
   activeIndex: number;
-  onChange: (index: number) => void;
+  onChange?: (index: number) => void;
 };
 
 const Container = styled.View`
@@ -63,7 +63,7 @@ function SlideIndicator({ slidesLength, activeIndex = 0, onChange }: Props): Rea
   return (
     <Container>
       {slidesArray.map((_, index) => (
-        <Bullet key={index} onPress={() => onChange(index)} />
+        <Bullet key={index} onPress={() => onChange && onChange(index)} />
       ))}
       <AnimatedBullet style={[animatedStyles]} />
     </Container>

--- a/packages/native/src/components/Navigation/StoriesIndicator/index.tsx
+++ b/packages/native/src/components/Navigation/StoriesIndicator/index.tsx
@@ -40,57 +40,39 @@ export interface StoriesIndicatorProps extends FlexBoxProps {
   duration?: number;
 }
 
-const ActiveBar = styled.View<{ full?: boolean }>`
+const ProgressBar = styled.View`
   background-color: ${(p) => p.theme.colors.primary.c100};
   height: 100%;
   width: 100%;
-  border-radius: 8px;
+  border-radius: ${(p) => p.theme.radii[2]}px;
 `;
 
-const AnimatedBar = Animated.createAnimatedComponent(ActiveBar);
+const AnimatedProgressBar = Animated.createAnimatedComponent(ProgressBar);
 
-export const TabsContainer = styled(Flex).attrs({
-  // Avoid conflict with styled-system's size property by nulling size and renaming it
-  size: undefined,
-  flexDirection: "row",
-  alignItems: "stretch",
-})`
-  width: 100%;
-`;
-
-function StoryBar({ full = false, isActive, duration }: StoryBarProps) {
-  const width = useSharedValue(full ? 100 : 0);
+function ActiveProgressBar({ duration }: StoryBarProps) {
+  const width = useSharedValue(0);
 
   useEffect(() => {
-    if (isActive) {
-      width.value = 100;
-    } else if (full) {
-      width.value = 0;
-    } else {
-      width.value = 0;
-    }
-  }, [isActive, full, width]);
+    width.value = 100;
+  }, [width]);
 
   const animatedStyles = useAnimatedStyle(
     () => ({
       width: withTiming(`${width.value}%`, {
-        duration: isActive ? duration || 200 : 0,
-        easing: duration ? Easing.linear : Easing.linear,
+        duration: duration || 200,
+        easing: Easing.linear,
       }),
     }),
-    [isActive, duration, full],
+    [width, duration],
   );
 
+  return <AnimatedProgressBar style={animatedStyles} />;
+}
+
+function StoryBar({ full = false, isActive, duration }: StoryBarProps) {
   return (
-    <Flex
-      height={4}
-      backgroundColor="neutral.c50"
-      margin={"auto"}
-      borderRadius={"8px"}
-      flex={1}
-      mx={1}
-    >
-      {full ? <ActiveBar /> : <AnimatedBar style={animatedStyles} />}
+    <Flex height={4} backgroundColor="neutral.c50" margin={"auto"} borderRadius={2} flex={1} mx={1}>
+      {isActive ? <ActiveProgressBar duration={duration} /> : full ? <ProgressBar /> : null}
     </Flex>
   );
 }
@@ -98,15 +80,16 @@ function StoryBar({ full = false, isActive, duration }: StoryBarProps) {
 function StoriesIndicator({ activeIndex, slidesLength, duration }: StoriesIndicatorProps) {
   const storiesArray = useMemo(() => new Array(slidesLength).fill(0), [slidesLength]);
   return (
-    <TabsContainer>
+    <Flex flexDirection={"row"} alignItems={"stretch"} width={"100%"}>
       {storiesArray.map((_, storyIndex) => (
         <StoryBar
+          key={storyIndex}
           full={activeIndex > storyIndex}
           isActive={activeIndex === storyIndex}
           duration={duration}
         />
       ))}
-    </TabsContainer>
+    </Flex>
   );
 }
 

--- a/packages/native/src/components/Navigation/StoriesIndicator/index.tsx
+++ b/packages/native/src/components/Navigation/StoriesIndicator/index.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useMemo } from "react";
+import styled from "styled-components/native";
+import Animated, {
+  useAnimatedStyle,
+  withTiming,
+  useSharedValue,
+  Easing,
+} from "react-native-reanimated";
+import { FlexBoxProps } from "../../Layout/Flex";
+import { Flex } from "../../Layout";
+
+export interface StoryBarProps {
+  /**
+   * Is this step active.
+   */
+  isActive?: boolean;
+  /**
+   * Has this step been completed.
+   */
+  full?: boolean;
+  /**
+   * The duration of this step.
+   */
+  duration?: number;
+}
+
+export interface StoriesIndicatorProps extends FlexBoxProps {
+  /**
+   * The index of the active step.
+   */
+  activeIndex: number;
+  /**
+   * The total number of steps.
+   */
+  slidesLength: number;
+  onChange?: (index: number) => void;
+  /**
+   * The duration of each step.
+   */
+  duration?: number;
+}
+
+const ActiveBar = styled.View<{ full?: boolean }>`
+  background-color: ${(p) => p.theme.colors.primary.c100};
+  height: 100%;
+  width: 100%;
+  border-radius: 8px;
+`;
+
+const AnimatedBar = Animated.createAnimatedComponent(ActiveBar);
+
+export const TabsContainer = styled(Flex).attrs({
+  // Avoid conflict with styled-system's size property by nulling size and renaming it
+  size: undefined,
+  flexDirection: "row",
+  alignItems: "stretch",
+})`
+  width: 100%;
+`;
+
+function StoryBar({ full = false, isActive, duration }: StoryBarProps) {
+  const width = useSharedValue(full ? 100 : 0);
+
+  useEffect(() => {
+    if (isActive) {
+      width.value = 100;
+    } else if (full) {
+      width.value = 0;
+    } else {
+      width.value = 0;
+    }
+  }, [isActive, full, width]);
+
+  const animatedStyles = useAnimatedStyle(
+    () => ({
+      width: withTiming(`${width.value}%`, {
+        duration: isActive ? duration || 200 : 0,
+        easing: duration ? Easing.linear : Easing.linear,
+      }),
+    }),
+    [isActive, duration, full],
+  );
+
+  return (
+    <Flex
+      height={4}
+      backgroundColor="neutral.c50"
+      margin={"auto"}
+      borderRadius={"8px"}
+      flex={1}
+      mx={1}
+    >
+      {full ? <ActiveBar /> : <AnimatedBar style={animatedStyles} />}
+    </Flex>
+  );
+}
+
+function StoriesIndicator({ activeIndex, slidesLength, duration }: StoriesIndicatorProps) {
+  const storiesArray = useMemo(() => new Array(slidesLength).fill(0), [slidesLength]);
+  return (
+    <TabsContainer>
+      {storiesArray.map((_, storyIndex) => (
+        <StoryBar
+          full={activeIndex > storyIndex}
+          isActive={activeIndex === storyIndex}
+          duration={duration}
+        />
+      ))}
+    </TabsContainer>
+  );
+}
+
+export default React.memo(StoriesIndicator);

--- a/packages/native/src/components/Navigation/index.ts
+++ b/packages/native/src/components/Navigation/index.ts
@@ -1,3 +1,4 @@
 export { default as SlideIndicator } from "./SlideIndicator";
 export { default as Stepper } from "./Stepper";
 export { default as FlowStepper } from "./FlowStepper";
+export { default as StoriesIndicator } from "./StoriesIndicator";

--- a/packages/native/storybook/stories/Carousel/Carousel.stories.tsx
+++ b/packages/native/storybook/stories/Carousel/Carousel.stories.tsx
@@ -64,7 +64,11 @@ const Item = ({ label }: { label: string }) => (
 
 const Default = (): JSX.Element => {
   return (
-    <Carousel>
+    <Carousel
+      scrollViewProps={{
+        style: { width: "100%" },
+      }}
+    >
       <Item label="primary" />
       <Item label="neutral" />
       <Item label="success" />
@@ -76,7 +80,14 @@ const Default = (): JSX.Element => {
 
 const AutoDelay = (): JSX.Element => {
   return (
-    <Carousel autoDelay={2000}>
+    <Carousel
+      autoDelay={2000}
+      scrollViewProps={{
+        style: {
+          width: "100%",
+        },
+      }}
+    >
       <Item label="primary" />
       <Item label="neutral" />
       <Item label="success" />
@@ -92,10 +103,10 @@ const WithProps = (): JSX.Element => {
     <Carousel
       containerProps={{
         p: 10,
-        backgroundColor: "neutral.c20",
+        backgroundColor: "red",
       }}
       scrollViewProps={{
-        style: { borderRadius: 20 },
+        style: { borderRadius: 20, width: "100%" },
       }}
       slideIndicatorContainerProps={{
         p: 4,
@@ -118,7 +129,15 @@ const Controlled = (): JSX.Element => {
 
   return (
     <>
-      <Carousel activeIndex={forceActiveIndex} onChange={setCarouselIndex}>
+      <Carousel
+        activeIndex={forceActiveIndex}
+        onChange={setCarouselIndex}
+        scrollViewProps={{
+          style: {
+            width: "100%",
+          },
+        }}
+      >
         <Item label="primary" />
         <Item label="neutral" />
         <Item label="success" />
@@ -147,6 +166,11 @@ const CustomIndicator = (): JSX.Element => {
       IndicatorComponent={StoriesIndicator}
       onOverflow={action("onOverflow")}
       onChange={action("onChange")}
+      scrollViewProps={{
+        style: {
+          width: "100%",
+        },
+      }}
       slideIndicatorContainerProps={{
         position: "absolute",
         top: 0,

--- a/packages/native/storybook/stories/Carousel/Carousel.stories.tsx
+++ b/packages/native/storybook/stories/Carousel/Carousel.stories.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import styled, { useTheme } from "styled-components/native";
+import { number, boolean } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
 import { storiesOf } from "../storiesOf";
 import { Flex, Carousel, Text, Button } from "../../../src";
+import StoriesIndicator from "../../../src/components/Navigation/StoriesIndicator";
 
 const description = `
 ### A simple responsive carousel.
@@ -135,6 +138,32 @@ const Controlled = (): JSX.Element => {
   );
 };
 
+const CustomIndicator = (): JSX.Element => {
+  return (
+    <Carousel
+      scrollOnSidePress={boolean("scrollOnSidePress", true)}
+      autoDelay={number("autoDelay", 5000)}
+      restartAfterEnd={boolean("restartAfterEnd", false)}
+      IndicatorComponent={StoriesIndicator}
+      onOverflow={action("onOverflow")}
+      onChange={action("onChange")}
+      slideIndicatorContainerProps={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        px: 7,
+      }}
+    >
+      <Item label="primary" />
+      <Item label="neutral" />
+      <Item label="success" />
+      <Item label="warning" />
+      <Item label="error" />
+    </Carousel>
+  );
+};
+
 storiesOf((story) =>
   story("Carousel", module)
     .add("Default", Default, {
@@ -147,5 +176,6 @@ storiesOf((story) =>
     })
     .add("AutoDelay", AutoDelay)
     .add("WithProps", WithProps)
-    .add("Controlled", Controlled),
+    .add("Controlled", Controlled)
+    .add("CustomIndicator - Story", CustomIndicator),
 );

--- a/packages/native/storybook/stories/Navigation/StoriesIndicator/StoriesIndicator.stories.tsx
+++ b/packages/native/storybook/stories/Navigation/StoriesIndicator/StoriesIndicator.stories.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import { number } from "@storybook/addon-knobs";
+import { storiesOf } from "../../storiesOf";
+import StoriesIndicator from "../../../../src/components/Navigation/StoriesIndicator";
+import { Box, Button, Text } from "../../../../src";
+
+const StoriesIndicatorSample = () => {
+  const [activeIndex, setActiveIndex] = useState<number>(1);
+
+  return (
+    <Box>
+      <Text textAlign={"center"}>{activeIndex}</Text>
+      <StoriesIndicator
+        activeIndex={activeIndex}
+        slidesLength={4}
+        duration={number("duration", 4000)}
+      />
+      <Button onPress={() => setActiveIndex(activeIndex - 1)}>back</Button>
+      <Button onPress={() => setActiveIndex(activeIndex + 1)}>next</Button>
+    </Box>
+  );
+};
+
+storiesOf((story) => story("Navigation", module).add("StoriesIndicator", StoriesIndicatorSample));

--- a/packages/native/storybook/stories/index.ts
+++ b/packages/native/storybook/stories/index.ts
@@ -14,6 +14,7 @@ import "./Layout/List/TipList.stories";
 import "./Layout/List/List.stories";
 import "./message/Notification/Notification.stories";
 import "./Navigation/SlideIndicator/SlideIndicator.stories";
+import "./Navigation/StoriesIndicator/StoriesIndicator.stories";
 import "./Navigation/Stepper/Stepper.stories";
 import "./Icon/BoxedIcon.stories";
 import "./Icon/IconBox.stories";


### PR DESCRIPTION
This is non-breaking changes

Add StoryIndicator, an indicator for Carousel component like Instagram stories

Add new options to Carousel (mostly to be able to have a Carousel like Instagram stories, like having the possibility to tap on side to scroll, custom indicator, no restart after carousel end etc)


- Fixes :
The delay was not resetting after scrolling
When scrolling to next item, the activeIndex was changing multiple time from the current index to the next index.


https://user-images.githubusercontent.com/89014981/168614676-ac610459-442e-418c-b5a4-637a4e1a079e.mp4


